### PR TITLE
Improve Performance for Adaptive Algorithms

### DIFF
--- a/Problems/CNTNV/CNTNV.m
+++ b/Problems/CNTNV/CNTNV.m
@@ -7,6 +7,10 @@
 %   *** number streams                  ***
 %   ***                                 ***
 %   *** Edited by David Newton 10/5/18  ***
+%   ***                                 ***
+%   *** Edited by Kurtis Konrad         ***
+%   *** 2/13/2020 Improve performance   ***
+%   *** when runlength==1               ***
 %   ***************************************
 
 
@@ -66,9 +70,16 @@ else
     RHDerivProfit = sellPrice * (demand > x) + salvage * (demand < x) - cost;   %partial derivative wrt x? not differentialble when demand=x
     
     % Calculate summary measures
-    fn = mean(profit);  %mean of sample mean
-    FnVar = var(profit) / runlength;	%variance of sample mean = var/n
-    FnGrad = mean(RHDerivProfit);
-    FnGradCov = var(RHDerivProfit) / runlength;
+    if runlength==1
+        fn=profit;
+        FnVar=0;
+        FnGrad=RHDerivProfit;
+        FnGradCov=0;
+    else
+        fn = mean(profit);  %mean of sample mean
+        FnVar = var(profit) / runlength;	%variance of sample mean = var/n
+        FnGrad = mean(RHDerivProfit);
+        FnGradCov = var(RHDerivProfit) / runlength;
+    end
     
 end

--- a/Problems/EOQ/EOQ.m
+++ b/Problems/EOQ/EOQ.m
@@ -18,9 +18,11 @@ function [fn, FnVar, FnGrad, FnGradCov, constraint, ConstraintCov, ConstraintGra
 %   *** Edited by Shane Henderson sgh9@cornell.edu, 7/14/14   ***
 %   ***                Edited by David Eckman                 ***
 %   ***          dje88@cornell.edu    Sept 14th, 2018         ***
+%   ***                Edited by Kurtis Konrad                ***
+%   ***            kekonrad@ncsu.edu    Feb 13, 2020          ***
 %   *************************************************************
 %
-% Last updated Sept 14, 2018
+% Last updated Feb 13, 2020
 
 %% -- SET known outputs 
 constraint = NaN;
@@ -63,8 +65,13 @@ else % main simulation
     end    
     
     %% Main
-    MeanRate = mean(rate);
-    VarRate = var(rate);
+    if runlength==1
+        MeanRate=rate;
+        VarRate=0;
+    else
+        MeanRate = mean(rate);
+        VarRate = var(rate);
+    end
     fn = (c + k / x) * MeanRate + h * x / 2;    %value of objective
     FnVar = (c + k / x)^2 * VarRate / runlength;
     FnGrad = (-k / x^2) * MeanRate + h / 2;

--- a/Problems/GPE/GPE.m
+++ b/Problems/GPE/GPE.m
@@ -18,7 +18,7 @@ function [fn, FnVar, FnGrad, FnGradCov, constraint, ConstraintCov, ConstraintGra
 %   ****************************************
 %
 
-% Last updated Oct 16, 2018 by David Newton
+% Last updated Feb 13, 2020 by Kurtis Konrad
 
 % RETURNS:  the value G_m giving the sample average of the log likelihood
 % m is the "runlength" input
@@ -65,8 +65,13 @@ else
     ReplicationVector = -y1 - y2 + (x(1) * y2 - 1).* log(y1) + (x(2)-1)* log(y2)-log(gamma(x(1)*y2))-log(gamma(x(2)));
   
     % Calculate summary measures
-    fn = mean(ReplicationVector);
-    FnVar = var(ReplicationVector)/runlength;
+    if runlength==1
+        fn = ReplicationVector;
+        FnVar = 0;
+    else
+        fn = mean(ReplicationVector);
+        FnVar = var(ReplicationVector)/runlength;
+    end
     FnGrad = NaN;
     FnGradCov = NaN;
     

--- a/Problems/QUEGG1/QUEGG1.m
+++ b/Problems/QUEGG1/QUEGG1.m
@@ -19,7 +19,7 @@ function [fn, FnVar, FnGrad, FnGradCov, constraint, ConstraintCov, ConstraintGra
 %   ***          bhc34@cornell.edu    September 13th, 2014    ***
 %   *************************************************************
 %
-% Last updated November 22, 2019
+% Last updated Februrary 13, 2020 by Kurtis Konrad
 
 %% -- SET known outputs (note that function only returns fn and FnVar)
 FnGrad = NaN;
@@ -94,7 +94,13 @@ else % main simulation
         end
         MeanCustTime(k) = mean(Customer(21:total,4));     % Calculate mean sojourn time for last 50 customers
     end
-    fn = mean(MeanCustTime)+ theta^2;                      % Mean and Variance of Alpha Function=Mean sojourn time + theta^2
-    FnVar = var(MeanCustTime)/nRuns;
+    if runlength==1
+        fn=MeanCustTime + theta^2;
+        FnVar=0;
+    else
+        fn = mean(MeanCustTime)+ theta^2;                      % Mean and Variance of Alpha Function=Mean sojourn time + theta^2
+        FnVar = var(MeanCustTime)/nRuns;
+    end
+    
 end
 end

--- a/Problems/SAN/SAN.m
+++ b/Problems/SAN/SAN.m
@@ -20,6 +20,8 @@ function [fn, FnVar, FnGrad, FnGradCov, constraint, ConstraintCov, ConstraintGra
 %   ***            bhc34@cornell.edu    Sept 10, 2014         ***
 %   ***                Edited by David Eckman                 ***
 %   ***            dje88@cornell.edu    Sept 4, 2018          ***
+%   ***                Edited by Kurtis Konrad                ***
+%   ***            kekonrad@ncsu.edu    Feb 13, 2020          ***
 %   *************************************************************
 
 constraint = NaN;
@@ -137,8 +139,15 @@ else % main simulation
     end
     
     % Calculate summary measures
-    fn = mean(cost);
-    FnVar = var(cost)/runlength;
-    FnGrad = mean(CostGrad, 1); % Calculates the mean of each column as desired
-    FnGradCov = cov(CostGrad); %FnGradCov = cov(CostGrad, 2);
+    if runlength==1
+        fn=cost;
+        FnVar=0;
+        FnGrad=CostGrad;
+        FnGradCov=zeros(length(CostGrad));
+    else
+        fn = mean(cost);
+        FnVar = var(cost)/runlength;
+        FnGrad = mean(CostGrad, 1); % Calculates the mean of each column as desired
+        FnGradCov = cov(CostGrad); %FnGradCov = cov(CostGrad, 2);
+    end
 end


### PR DESCRIPTION
After examining causes of ASTRDF's slow performance, I found that certain simple functions were unnecessary when runlength==1, but they were adding significant time for the solver.  These changes have now improved the adaptive sampling performance on these functions.