### PR TITLE
Added Scrollbars to Prob/Solv Datafarming Window

### DIFF
--- a/simopt/gui/main_menu.py
+++ b/simopt/gui/main_menu.py
@@ -93,16 +93,18 @@ class MainMenuWindow(Toplevel):
         self.style.configure("TLabel", font=nametofont("TkTextFont"))
         self.style.configure("TButton", font=nametofont("TkTextFont"))
 
+    def __open_window(self, class_name: type) -> None:
+        """Open a new window."""
+        self.reset_main_menu_style_changes()
+        new_window = class_name(self.root)
+        self.destroy()
+        # Bring new window to front
+        new_window.lift()
+
     def open_model_datafarming(self) -> None:
         """Open the model data farming window."""
-        self.reset_main_menu_style_changes()
-        DataFarmingWindow(self.root)
-        # Configure the exit button to close the window and close the menu
-        self.destroy()
+        self.__open_window(DataFarmingWindow)
 
     def open_new_experiment(self) -> None:
-        self.reset_main_menu_style_changes()
         """Open the new experiment window."""
-        NewExperimentWindow(self.root)
-        # Configure the exit button to close the window and close the menu
-        self.destroy()
+        self.__open_window(NewExperimentWindow)

--- a/simopt/gui/main_menu.py
+++ b/simopt/gui/main_menu.py
@@ -31,23 +31,12 @@ class MainMenuWindow(Toplevel):
         self.menu_frame.pack(anchor="center", expand=True)
 
         # Create new style for the labels and buttons
-        header_font = nametofont("TkHeadingFont").copy()
-        header_font_size = header_font.cget("size")
-        scaled_header_font_size = int(header_font_size * FONT_SCALE)
-        header_font.configure(size=scaled_header_font_size)
+        self.set_main_menu_style_changes()
 
-        option_font = nametofont("TkTextFont").copy()
-        option_font_size = option_font.cget("size")
-        scaled_option_font_size = int(option_font_size * FONT_SCALE)
-        option_font.configure(size=scaled_option_font_size)
-        self.style.configure("TButton", font=option_font)
-        button_padding = scaled_option_font_size
-
-        self.title_label = tk.Label(
+        self.title_label = ttk.Label(
             master=self.menu_frame,
             text="Welcome to SimOpt Library Graphic User Interface",
             justify="center",
-            font=header_font,
         )
         self.title_label.grid(row=0, column=0, pady=10, sticky="nsew")
 
@@ -67,8 +56,8 @@ class MainMenuWindow(Toplevel):
             column=0,
             pady=10,
             sticky="nsew",
-            ipadx=button_padding,
-            ipady=button_padding,
+            ipadx=20,
+            ipady=20,
         )
 
         # Button to open new experiment window
@@ -82,17 +71,37 @@ class MainMenuWindow(Toplevel):
             column=0,
             pady=10,
             sticky="nsew",
-            ipadx=button_padding,
-            ipady=button_padding,
+            ipadx=20,
+            ipady=20,
         )
+
+    def set_main_menu_style_changes(self) -> None:
+        self.header_font = nametofont("TkHeadingFont").copy()
+        header_font_size = self.header_font.cget("size")
+        scaled_header_font_size = int(header_font_size * FONT_SCALE)
+        self.header_font.configure(size=scaled_header_font_size)
+        self.style.configure("TLabel", font=self.header_font)
+
+        self.option_font = nametofont("TkTextFont").copy()
+        option_font_size = self.option_font.cget("size")
+        scaled_option_font_size = int(option_font_size * FONT_SCALE)
+        self.option_font.configure(size=scaled_option_font_size)
+        self.style.configure("TButton", font=self.option_font)
+
+    def reset_main_menu_style_changes(self) -> None:
+        """Reset the style of the buttons."""
+        self.style.configure("TLabel", font=nametofont("TkTextFont"))
+        self.style.configure("TButton", font=nametofont("TkTextFont"))
 
     def open_model_datafarming(self) -> None:
         """Open the model data farming window."""
+        self.reset_main_menu_style_changes()
         DataFarmingWindow(self.root)
         # Configure the exit button to close the window and close the menu
         self.destroy()
 
     def open_new_experiment(self) -> None:
+        self.reset_main_menu_style_changes()
         """Open the new experiment window."""
         NewExperimentWindow(self.root)
         # Configure the exit button to close the window and close the menu

--- a/simopt/gui/main_menu.py
+++ b/simopt/gui/main_menu.py
@@ -75,6 +75,9 @@ class MainMenuWindow(Toplevel):
             ipady=20,
         )
 
+        # Prevent window from getting launched in the background
+        self.lift()
+
     def set_main_menu_style_changes(self) -> None:
         self.header_font = nametofont("TkHeadingFont").copy()
         header_font_size = self.header_font.cget("size")

--- a/simopt/gui/main_menu.py
+++ b/simopt/gui/main_menu.py
@@ -1,10 +1,13 @@
 import tkinter as tk
+from tkinter import ttk
 from tkinter.font import nametofont
+from typing import Final
 
 from simopt.gui.data_farming_window import DataFarmingWindow
-from simopt.gui.experiment_window import ExperimentWindow
 from simopt.gui.new_experiment_window import NewExperimentWindow
 from simopt.gui.toplevel_custom import Toplevel
+
+FONT_SCALE: Final[float] = 1.5
 
 
 class MainMenuWindow(Toplevel):
@@ -24,72 +27,64 @@ class MainMenuWindow(Toplevel):
         )
         self.center_window(0.8)  # 80% scaling
 
-        self.menu_frame = tk.Frame(master=self)
-        self.menu_frame.pack(anchor="center")
+        self.menu_frame = ttk.Frame(master=self)
+        self.menu_frame.pack(anchor="center", expand=True)
 
-        font_scale = 1.5
+        # Create new style for the labels and buttons
         header_font = nametofont("TkHeadingFont").copy()
-        header_font.configure(size=int(header_font.cget("size") * font_scale))
-        option_font = nametofont("TkMenuFont").copy()
-        option_font.configure(size=int(option_font.cget("size") * font_scale))
+        header_font_size = header_font.cget("size")
+        scaled_header_font_size = int(header_font_size * FONT_SCALE)
+        header_font.configure(size=scaled_header_font_size)
+
+        option_font = nametofont("TkTextFont").copy()
+        option_font_size = option_font.cget("size")
+        scaled_option_font_size = int(option_font_size * FONT_SCALE)
+        option_font.configure(size=scaled_option_font_size)
+        self.style.configure("TButton", font=option_font)
+        button_padding = scaled_option_font_size
 
         self.title_label = tk.Label(
             master=self.menu_frame,
             text="Welcome to SimOpt Library Graphic User Interface",
-            font=header_font,
             justify="center",
+            font=header_font,
         )
-        self.title_label.grid(row=0, column=0, pady=20)
+        self.title_label.grid(row=0, column=0, pady=10, sticky="nsew")
 
-        # Button to open original main window to run experiments across solvers & problems
-        self.experiment_button = tk.Button(
-            master=self.menu_frame,
-            text="Run Single Problem-Solver Experiment",
-            font=option_font,
-            command=self.open_experiment_window,
+        self.separator = ttk.Separator(
+            master=self.menu_frame, orient="horizontal"
         )
-        self.experiment_button.grid(row=1, column=0, pady=10, sticky="nsew")
-        self.experiment_button.configure(background="light gray")
+        self.separator.grid(row=1, column=0, pady=10, sticky="nsew")
 
         # Button to open model data farming window
-        self.datafarm_model_button = tk.Button(
+        self.datafarm_model_button = ttk.Button(
             master=self.menu_frame,
             text="Data Farm Models",
-            font=option_font,
             command=self.open_model_datafarming,
         )
-        self.datafarm_model_button.grid(row=2, column=0, pady=10, sticky="nsew")
-        self.datafarm_model_button.configure(background="light gray")
-
-        # # Button to open solver & problem data farming window
-        # self.datafarm_prob_sol_button = tk.Button(
-        #     master=self.menu_frame,
-        #     text="Solver Data Farming",
-        #     font=option_font,
-        #     command=self.open_prob_sol_datafarming,
-        # )
-        # self.datafarm_prob_sol_button.grid(row=3, column=0, pady=10, sticky="nsew")
-        # self.datafarm_prob_sol_button.configure(background="light gray")
+        self.datafarm_model_button.grid(
+            row=2,
+            column=0,
+            pady=10,
+            sticky="nsew",
+            ipadx=button_padding,
+            ipady=button_padding,
+        )
 
         # Button to open new experiment window
-        self.new_experiment_button = tk.Button(
+        self.new_experiment_button = ttk.Button(
             master=self.menu_frame,
-            text="Data Farm Problems and Solvers",
-            font=option_font,
+            text="Data Farm Problems and/or Solvers",
             command=self.open_new_experiment,
         )
-        self.new_experiment_button.grid(row=4, column=0, pady=10, sticky="nsew")
-        self.new_experiment_button.configure(background="light gray")
-
-        # Open the new experiment window and hide the main menu window
-        # self.open_new_experiment()
-        # self.withdraw()
-
-    def open_experiment_window(self) -> None:
-        """Open the experiment window."""
-        ExperimentWindow(self.root)
-        # Configure the exit button to close the window and close the menu
-        self.destroy()
+        self.new_experiment_button.grid(
+            row=3,
+            column=0,
+            pady=10,
+            sticky="nsew",
+            ipadx=button_padding,
+            ipady=button_padding,
+        )
 
     def open_model_datafarming(self) -> None:
         """Open the model data farming window."""

--- a/simopt/gui/new_experiment_window.py
+++ b/simopt/gui/new_experiment_window.py
@@ -487,7 +487,9 @@ class NewExperimentWindow(Toplevel):
             command=self.tk_canvases["ntbk.ps_adding.problem.factors"].yview,
         )
         self.tk_canvases["ntbk.ps_adding.problem.factors"].config(
-            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.problem.factors"].set
+            yscrollcommand=self.tk_scrollbars[
+                "ntbk.ps_adding.problem.factors"
+            ].set
         )
         self.tk_scrollbars["ntbk.ps_adding.problem.factors"].grid(
             row=1, column=2, sticky="ns"
@@ -535,7 +537,9 @@ class NewExperimentWindow(Toplevel):
             command=self.tk_canvases["ntbk.ps_adding.solver.factors"].yview,
         )
         self.tk_canvases["ntbk.ps_adding.solver.factors"].config(
-            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.solver.factors"].set
+            yscrollcommand=self.tk_scrollbars[
+                "ntbk.ps_adding.solver.factors"
+            ].set
         )
         self.tk_scrollbars["ntbk.ps_adding.solver.factors"].grid(
             row=1, column=2, sticky="ns"
@@ -587,7 +591,7 @@ class NewExperimentWindow(Toplevel):
             error_msg = f"Canvas {canvas_name} not found in GUI"
             raise ValueError(error_msg)
         canvas = self.tk_canvases[canvas_name]
-        # Update the scroll region
+        # Make sure it's up to date before updating the scroll region
         canvas.update()
         canvas.config(scrollregion=canvas.bbox("all"))
 
@@ -605,7 +609,7 @@ class NewExperimentWindow(Toplevel):
 
     def __update_solver_factor_scroll_region(self) -> None:
         self.__update_canvas_scroll_region("ntbk.ps_adding.solver.factors")
-    
+
     def __update_quick_add_problems_scroll_region(self) -> None:
         self.__update_canvas_scroll_region("ntbk.ps_adding.quick_add.problems")
 
@@ -670,6 +674,9 @@ class NewExperimentWindow(Toplevel):
         self.tk_buttons["design_opts.generate"].grid(
             row=1, column=2, sticky="nsew", rowspan=3
         )
+        # We start on the first tab (Add Problem) so we need to initialize the
+        # problem factors canvas
+        self.__refresh_problem_tab()
 
     def _hide_gen_design(self) -> None:
         self.tk_frames["gen_design"].grid_remove()
@@ -689,6 +696,39 @@ class NewExperimentWindow(Toplevel):
         self.tk_entries["design_opts.num_stacks"].configure(state="normal")
         self.tk_entries["design_opts.name"].configure(state="normal")
 
+    def __refresh_problem_tab(self) -> None:
+        self.selected_problem_name.set("")
+        self._enable_design_opts()
+        self._destroy_widget_children(
+            self.tk_canvases["ntbk.ps_adding.problem.factors"]
+        )
+        self.tk_buttons["design_opts.generate"].configure(
+            text="Generate Problem Design",
+            command=self.create_problem_design,
+        )
+        self.__update_problem_factor_scroll_region()
+
+    def __refresh_solver_tab(self) -> None:
+        self.selected_solver_name.set("")
+        self._enable_design_opts()
+        self._destroy_widget_children(
+            self.tk_canvases["ntbk.ps_adding.solver.factors"]
+        )
+        self.tk_buttons["design_opts.generate"].configure(
+            text="Generate Solver Design", command=self.create_solver_design
+        )
+        self.__update_solver_factor_scroll_region()
+
+    def __refresh_quick_add_tab(self) -> None:
+        self._disable_design_opts()
+        self.__initialize_quick_add()
+        self.tk_buttons["design_opts.generate"].configure(
+            text="Add Cross Design to Experiment",
+            command=self.create_cross_design,
+        )
+        self.__update_quick_add_problems_scroll_region()
+        self.__update_quick_add_solvers_scroll_region()
+
     # Event handler for when the user changes the notebook tab
     def _on_notebook_tab_change(self, event: tk.Event) -> None:
         # Hide the generated design frame
@@ -703,34 +743,11 @@ class NewExperimentWindow(Toplevel):
         tab_name = event.widget.tab(event.widget.select(), "text")
         # Switch on the tab name
         if tab_name == "Add Problem":
-            self.selected_problem_name.set("")
-            self._enable_design_opts()
-            self._destroy_widget_children(
-                self.tk_canvases["ntbk.ps_adding.problem.factors"]
-            )
-            self.tk_buttons["design_opts.generate"].configure(
-                text="Generate Problem Design",
-                command=self.create_problem_design,
-            )
-
+            self.__refresh_problem_tab()
         elif tab_name == "Add Solver":
-            self.selected_solver_name.set("")
-            self._enable_design_opts()
-            self._destroy_widget_children(
-                self.tk_canvases["ntbk.ps_adding.solver.factors"]
-            )
-            self.tk_buttons["design_opts.generate"].configure(
-                text="Generate Solver Design", command=self.create_solver_design
-            )
-
+            self.__refresh_solver_tab()
         elif tab_name == "Quick-Add Problems/Solvers":
-            self._disable_design_opts()
-            self.__initialize_quick_add()
-            self.tk_buttons["design_opts.generate"].configure(
-                text="Add Cross Design to Experiment",
-                command=self.create_cross_design,
-            )
-
+            self.__refresh_quick_add_tab()
         else:
             error_msg = f"Unknown tab name: {tab_name}"
             raise ValueError(error_msg)
@@ -954,7 +971,9 @@ class NewExperimentWindow(Toplevel):
             command=self.tk_canvases["ntbk.ps_adding.quick_add.problems"].yview,
         )
         self.tk_canvases["ntbk.ps_adding.quick_add.problems"].config(
-            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.quick_add.problems"].set
+            yscrollcommand=self.tk_scrollbars[
+                "ntbk.ps_adding.quick_add.problems"
+            ].set
         )
         self.tk_scrollbars["ntbk.ps_adding.quick_add.problems"].grid(
             row=2, column=1, sticky="ns"
@@ -972,7 +991,9 @@ class NewExperimentWindow(Toplevel):
             command=self.tk_canvases["ntbk.ps_adding.quick_add.solvers"].yview,
         )
         self.tk_canvases["ntbk.ps_adding.quick_add.solvers"].config(
-            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.quick_add.solvers"].set
+            yscrollcommand=self.tk_scrollbars[
+                "ntbk.ps_adding.quick_add.solvers"
+            ].set
         )
         self.tk_scrollbars["ntbk.ps_adding.quick_add.solvers"].grid(
             row=2, column=4, sticky="ns"
@@ -1065,6 +1086,9 @@ class NewExperimentWindow(Toplevel):
             self.tk_checkbuttons[tk_name].grid(
                 row=row, column=0, sticky="w", padx=10
             )
+        # Update the scroll region
+        self.__update_quick_add_problems_scroll_region()
+        self.__update_quick_add_solvers_scroll_region()
         # Run the compatibility checks
         self.cross_design_problem_compatibility()
         self.cross_design_solver_compatibility()
@@ -1376,15 +1400,16 @@ class NewExperimentWindow(Toplevel):
             "# Decimals",
         ]
         for heading in header_columns:
-            frame.grid_columnconfigure(header_columns.index(heading), weight=1)
-            label = tk.Label(
+            column_idx = header_columns.index(heading)
+            frame.grid_columnconfigure(column_idx, weight=1)
+            label = ttk.Label(
                 master=frame,
                 text=heading,
                 font=nametofont("TkHeadingFont"),
             )
             label.grid(
                 row=first_row,
-                column=header_columns.index(heading),
+                column=column_idx,
                 padx=10,
             )
         # Insert horizontal separator
@@ -1403,7 +1428,7 @@ class NewExperimentWindow(Toplevel):
 
         Parameters
         ----------
-        frame : tk.Frame
+        frame : ttk.Frame
             Frame to display factors.
         factors : dict[str, DFFactor]
             Dictionary of factors.
@@ -1438,28 +1463,29 @@ class NewExperimentWindow(Toplevel):
             ]
 
             # If it's not the last row, add a separator
-            if factor_index != len(factor_dict) - 1:
+            last_row_idx = len(factor_dict) - 1
+            if factor_index != last_row_idx:
                 ttk.Separator(frame, orient="horizontal").grid(
                     row=row_index + 1,
                     column=0,
                     columnspan=len(column_functions),
-                    sticky=tk.E + tk.W,
+                    sticky="ew",
                 )
 
             # Loop through and insert the factor data into the frame
             for column_index, function in enumerate(column_functions):
                 widget = function(frame)
-                # Display the widget if it exists
-                if widget is not None:
-                    widget.grid(
-                        row=row_index,
-                        column=column_index,
-                        padx=10,
-                        pady=3,
-                        sticky="ew",
-                    )
-                else:
+                # Stop if we're out of widgets
+                if widget is None:
                     break
+                # Add the widget if it isn't none
+                widget.grid(
+                    row=row_index,
+                    column=column_index,
+                    padx=10,
+                    pady=3,
+                    sticky="ew",
+                )
         return row_index
 
     def _create_problem_factors_canvas(self, problem: Problem) -> None:
@@ -1472,8 +1498,10 @@ class NewExperimentWindow(Toplevel):
         self.tk_frames["ntbk.ps_adding.problem.factors.problems"] = ttk.Frame(
             master=self.tk_canvases["ntbk.ps_adding.problem.factors"],
         )
-        self.tk_frames["ntbk.ps_adding.problem.factors.problems"].grid(
-            row=0, column=0, sticky="nsew"
+        self.tk_canvases["ntbk.ps_adding.problem.factors"].create_window(
+            (0, 0),
+            window=self.tk_frames["ntbk.ps_adding.problem.factors.problems"],
+            anchor="nw",
         )
 
         # show problem factors and store default widgets to this dict
@@ -1481,6 +1509,8 @@ class NewExperimentWindow(Toplevel):
             problem,
             frame=self.tk_frames["ntbk.ps_adding.problem.factors.problems"],
         )
+        # Update the scroll region
+        self.__update_problem_factor_scroll_region()
 
         # Update the design name to be unique
         unique_name = self.get_unique_problem_name(problem.name)
@@ -1498,8 +1528,10 @@ class NewExperimentWindow(Toplevel):
         self.tk_frames["ntbk.ps_adding.solver.factors.solvers"] = ttk.Frame(
             master=self.tk_canvases["ntbk.ps_adding.solver.factors"],
         )
-        self.tk_frames["ntbk.ps_adding.solver.factors.solvers"].grid(
-            row=0, column=0, sticky="nsew"
+        self.tk_canvases["ntbk.ps_adding.solver.factors"].create_window(
+            (0, 0),
+            window=self.tk_frames["ntbk.ps_adding.solver.factors.solvers"],
+            anchor="nw",
         )
 
         # show problem factors and store default widgets to this dict
@@ -1507,6 +1539,8 @@ class NewExperimentWindow(Toplevel):
             solver,
             frame=self.tk_frames["ntbk.ps_adding.solver.factors.solvers"],
         )
+        # Update the scroll region
+        self.__update_solver_factor_scroll_region()
 
         # Update the design name to be unique
         unique_name = self.get_unique_solver_name(solver.name)
@@ -1526,7 +1560,7 @@ class NewExperimentWindow(Toplevel):
 
         Returns
         -------
-        new_name : str
+        str
             new unique name.
 
         """
@@ -1540,16 +1574,9 @@ class NewExperimentWindow(Toplevel):
                 test_name = base_name
                 count += 1
                 test_name = f"{base_name}_{count!s}"
-            new_name = test_name
+            return test_name
         else:
-            new_name = base_name
-
-        # if base_name != new_name:
-        #     print(
-        #         f"Name {base_name} already exists. New name: {new_name}"
-        #     )
-
-        return new_name
+            return base_name
 
     def get_unique_experiment_name(self, base_name: str) -> str:
         return self.__get_unique_name(self.root_experiment_dict, base_name)

--- a/simopt/gui/new_experiment_window.py
+++ b/simopt/gui/new_experiment_window.py
@@ -470,7 +470,7 @@ class NewExperimentWindow(Toplevel):
             state="readonly",
         )
         self.tk_comboboxes["ntbk.ps_adding.problem.select"].grid(
-            row=0, column=1, sticky="ew", padx=5
+            row=0, column=1, sticky="ew", columnspan=2
         )
         self.tk_comboboxes["ntbk.ps_adding.problem.select"].bind(
             "<<ComboboxSelected>>", self._on_problem_combobox_change
@@ -481,6 +481,18 @@ class NewExperimentWindow(Toplevel):
         self.tk_canvases["ntbk.ps_adding.problem.factors"].grid(
             row=1, column=0, sticky="nsew", columnspan=2
         )
+        self.tk_scrollbars["ntbk.ps_adding.problem.factors"] = ttk.Scrollbar(
+            self.tk_frames["ntbk.ps_adding.problem"],
+            orient="vertical",
+            command=self.tk_canvases["ntbk.ps_adding.problem.factors"].yview,
+        )
+        self.tk_canvases["ntbk.ps_adding.problem.factors"].config(
+            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.problem.factors"].set
+        )
+        self.tk_scrollbars["ntbk.ps_adding.problem.factors"].grid(
+            row=1, column=2, sticky="ns"
+        )
+        self.__update_problem_factor_scroll_region()
 
         self.tk_frames["ntbk.ps_adding.solver"] = ttk.Frame(
             self.tk_notebooks["ntbk.ps_adding"]
@@ -506,7 +518,7 @@ class NewExperimentWindow(Toplevel):
             state="readonly",
         )
         self.tk_comboboxes["ntbk.ps_adding.solver.select"].grid(
-            row=0, column=1, sticky="ew", padx=5
+            row=0, column=1, sticky="ew", columnspan=2
         )
         self.tk_comboboxes["ntbk.ps_adding.solver.select"].bind(
             "<<ComboboxSelected>>", self._on_solver_combobox_change
@@ -517,6 +529,18 @@ class NewExperimentWindow(Toplevel):
         self.tk_canvases["ntbk.ps_adding.solver.factors"].grid(
             row=1, column=0, sticky="nsew", columnspan=2
         )
+        self.tk_scrollbars["ntbk.ps_adding.solver.factors"] = ttk.Scrollbar(
+            self.tk_frames["ntbk.ps_adding.solver"],
+            orient="vertical",
+            command=self.tk_canvases["ntbk.ps_adding.solver.factors"].yview,
+        )
+        self.tk_canvases["ntbk.ps_adding.solver.factors"].config(
+            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.solver.factors"].set
+        )
+        self.tk_scrollbars["ntbk.ps_adding.solver.factors"].grid(
+            row=1, column=2, sticky="ns"
+        )
+        self.__update_solver_factor_scroll_region()
 
         self.tk_frames["ntbk.ps_adding.quick_add"] = ttk.Frame(
             self.tk_notebooks["ntbk.ps_adding"]
@@ -530,7 +554,7 @@ class NewExperimentWindow(Toplevel):
         )
         # Initialize the quick-add tab
         # If this doesn't get initialized, the compatability checks will fail
-        self._add_with_default_options()
+        self.__initialize_quick_add()
 
     def _initialize_generated_design_frame(self) -> None:
         if "gen_design" in self.tk_frames:
@@ -575,6 +599,18 @@ class NewExperimentWindow(Toplevel):
 
     def __update_solver_list_scroll_region(self) -> None:
         self.__update_canvas_scroll_region("curr_exp.lists.solvers")
+
+    def __update_problem_factor_scroll_region(self) -> None:
+        self.__update_canvas_scroll_region("ntbk.ps_adding.problem.factors")
+
+    def __update_solver_factor_scroll_region(self) -> None:
+        self.__update_canvas_scroll_region("ntbk.ps_adding.solver.factors")
+    
+    def __update_quick_add_problems_scroll_region(self) -> None:
+        self.__update_canvas_scroll_region("ntbk.ps_adding.quick_add.problems")
+
+    def __update_quick_add_solvers_scroll_region(self) -> None:
+        self.__update_canvas_scroll_region("ntbk.ps_adding.quick_add.solvers")
 
     def _initialize_design_options(self) -> None:
         if "design_opts" in self.tk_frames:
@@ -689,7 +725,7 @@ class NewExperimentWindow(Toplevel):
 
         elif tab_name == "Quick-Add Problems/Solvers":
             self._disable_design_opts()
-            self._add_with_default_options()
+            self.__initialize_quick_add()
             self.tk_buttons["design_opts.generate"].configure(
                 text="Add Cross Design to Experiment",
                 command=self.create_cross_design,
@@ -850,28 +886,26 @@ class NewExperimentWindow(Toplevel):
         )
         self.__update_solver_list_scroll_region()
 
-    def _add_with_default_options(self) -> None:
+    def __initialize_quick_add(self) -> None:
         # Delete all existing children of the frame
         for child in self.tk_frames[
             "ntbk.ps_adding.quick_add"
         ].winfo_children():
             child.destroy()
         # Configure the grid layout to expand properly
-        problem_frame_weight = 2
-        solver_frame_weight = 1
         self.tk_frames["ntbk.ps_adding.quick_add"].grid_rowconfigure(
             2, weight=1
         )
         self.tk_frames["ntbk.ps_adding.quick_add"].grid_columnconfigure(
-            0, weight=problem_frame_weight
+            0, weight=2
         )
         self.tk_frames["ntbk.ps_adding.quick_add"].grid_columnconfigure(
-            1, weight=solver_frame_weight
+            3, weight=1
         )
 
         # Create labels for the title and the column headers
         title_text = "Select problems/solvers to be included in cross-design."
-        title_text += "\nThese will be added with default factor settings."
+        title_text += " These will be added with default factor settings."
         self.tk_labels["ntbk.ps_adding.quick_add.title"] = ttk.Label(
             self.tk_frames["ntbk.ps_adding.quick_add"],
             text=title_text,
@@ -879,7 +913,7 @@ class NewExperimentWindow(Toplevel):
             justify="center",
         )
         self.tk_labels["ntbk.ps_adding.quick_add.title"].grid(
-            row=0, column=0, columnspan=2
+            row=0, column=0, columnspan=5, sticky="ew"
         )
         self.tk_labels["ntbk.ps_adding.quick_add.problems"] = ttk.Label(
             self.tk_frames["ntbk.ps_adding.quick_add"],
@@ -888,7 +922,14 @@ class NewExperimentWindow(Toplevel):
             font=nametofont("TkHeadingFont"),
         )
         self.tk_labels["ntbk.ps_adding.quick_add.problems"].grid(
-            row=1, column=0, sticky="ew"
+            row=1, column=0, sticky="ew", columnspan=2
+        )
+        self.tk_separators["ntbk.ps_adding.quick_add"] = ttk.Separator(
+            self.tk_frames["ntbk.ps_adding.quick_add"],
+            orient="vertical",
+        )
+        self.tk_separators["ntbk.ps_adding.quick_add"].grid(
+            row=1, column=2, sticky="ns", rowspan=2, padx=10
         )
         self.tk_labels["ntbk.ps_adding.quick_add.solvers"] = ttk.Label(
             self.tk_frames["ntbk.ps_adding.quick_add"],
@@ -897,7 +938,7 @@ class NewExperimentWindow(Toplevel):
             font=nametofont("TkHeadingFont"),
         )
         self.tk_labels["ntbk.ps_adding.quick_add.solvers"].grid(
-            row=1, column=1, sticky="ew"
+            row=1, column=3, sticky="ew", columnspan=2
         )
 
         # Create canvases for the problems and solvers
@@ -907,11 +948,34 @@ class NewExperimentWindow(Toplevel):
         self.tk_canvases["ntbk.ps_adding.quick_add.problems"].grid(
             row=2, column=0, sticky="nsew"
         )
+        self.tk_scrollbars["ntbk.ps_adding.quick_add.problems"] = ttk.Scrollbar(
+            self.tk_frames["ntbk.ps_adding.quick_add"],
+            orient="vertical",
+            command=self.tk_canvases["ntbk.ps_adding.quick_add.problems"].yview,
+        )
+        self.tk_canvases["ntbk.ps_adding.quick_add.problems"].config(
+            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.quick_add.problems"].set
+        )
+        self.tk_scrollbars["ntbk.ps_adding.quick_add.problems"].grid(
+            row=2, column=1, sticky="ns"
+        )
+
         self.tk_canvases["ntbk.ps_adding.quick_add.solvers"] = tk.Canvas(
             self.tk_frames["ntbk.ps_adding.quick_add"]
         )
         self.tk_canvases["ntbk.ps_adding.quick_add.solvers"].grid(
-            row=2, column=1, sticky="nsew"
+            row=2, column=3, sticky="nsew"
+        )
+        self.tk_scrollbars["ntbk.ps_adding.quick_add.solvers"] = ttk.Scrollbar(
+            self.tk_frames["ntbk.ps_adding.quick_add"],
+            orient="vertical",
+            command=self.tk_canvases["ntbk.ps_adding.quick_add.solvers"].yview,
+        )
+        self.tk_canvases["ntbk.ps_adding.quick_add.solvers"].config(
+            yscrollcommand=self.tk_scrollbars["ntbk.ps_adding.quick_add.solvers"].set
+        )
+        self.tk_scrollbars["ntbk.ps_adding.quick_add.solvers"].grid(
+            row=2, column=4, sticky="ns"
         )
 
         # create master frame inside the canvas
@@ -1127,7 +1191,7 @@ class NewExperimentWindow(Toplevel):
             return
 
         # Reset the quick-add frame
-        self._add_with_default_options()
+        self.__initialize_quick_add()
         # Reset all the booleans
         for key in self.tk_var_bools:
             if "ntbk.ps_adding.quick_add.problems_frame" in key:

--- a/simopt/gui/new_experiment_window.py
+++ b/simopt/gui/new_experiment_window.py
@@ -151,8 +151,8 @@ class NewExperimentWindow(Toplevel):
         # Setup the main frame
         self.tk_frames["main"] = ttk.Frame(self)
         self.tk_frames["main"].pack(fill="both", expand=True)
-        self.tk_frames["main"].grid_columnconfigure(0, weight=1)
-        self.tk_frames["main"].grid_columnconfigure(1, weight=2)
+        self.tk_frames["main"].grid_columnconfigure(0, weight=3)
+        self.tk_frames["main"].grid_columnconfigure(1, weight=5)
         self.tk_frames["main"].grid_rowconfigure(0, weight=1)
         # Configure the left side of the window
         self.tk_frames["left"] = ttk.Frame(self.tk_frames["main"])
@@ -196,6 +196,7 @@ class NewExperimentWindow(Toplevel):
         )
         self.tk_frames["exps.list_canvas"].grid(row=1, column=0, sticky="nsew")
         self.tk_frames["exps.list_canvas"].grid_columnconfigure(0, weight=1)
+        self.tk_frames["exps.list_canvas"].grid_rowconfigure(0, weight=1)
         self.tk_canvases["exps.list_canvas"] = tk.Canvas(
             self.tk_frames["exps.list_canvas"],
         )

--- a/simopt/gui/new_experiment_window.py
+++ b/simopt/gui/new_experiment_window.py
@@ -1775,7 +1775,8 @@ class NewExperimentWindow(Toplevel):
             text=f"Add this {base_object} design to experiment",
             command=command,
         )
-        self.tk_buttons["gen_design.add"].grid(row=1, column=0, sticky="nsew")
+        # Design tree is in row 0, horizontal scrollbar is in row 1
+        self.tk_buttons["gen_design.add"].grid(row=2, column=0, sticky="nsew")
 
     def create_solver_design(self) -> None:
         self.__create_design_core("Solver")
@@ -1851,6 +1852,15 @@ class NewExperimentWindow(Toplevel):
             header_font_size = nametofont("TkHeadingFont").cget("size")
             width = max_width * header_font_size * 0.8 + 10
             self.design_tree.column(column, width=int(width))
+        
+        # Add a horizontal scrollbar
+        self.design_tree_scroll_x = ttk.Scrollbar(
+            master=master_frame,
+            orient="horizontal",
+            command=self.design_tree.xview,
+        )
+        self.design_tree_scroll_x.grid(row=1, column=0, sticky="ew")
+        self.design_tree.configure(xscrollcommand=self.design_tree_scroll_x.set)
 
     def __read_in_generated_design(self) -> pd.DataFrame:
         # Get the design table from the treeview

--- a/simopt/gui/new_experiment_window.py
+++ b/simopt/gui/new_experiment_window.py
@@ -1770,13 +1770,11 @@ class NewExperimentWindow(Toplevel):
             if base_object == "Problem"
             else self.add_solver_design_to_experiment
         )
-        self.tk_buttons["gen_design.add"] = ttk.Button(
-            master=self.tk_frames["gen_design.display"],
+        self.tk_buttons["gen_design.add"].config(
             text=f"Add this {base_object} design to experiment",
             command=command,
         )
-        # Design tree is in row 0, horizontal scrollbar is in row 1
-        self.tk_buttons["gen_design.add"].grid(row=2, column=0, sticky="nsew")
+        self.tk_buttons["gen_design.add"].grid()
 
     def create_solver_design(self) -> None:
         self.__create_design_core("Solver")
@@ -1807,6 +1805,8 @@ class NewExperimentWindow(Toplevel):
         if master_frame is None:
             master_frame = self.tk_frames["gen_design.display"]
 
+        # Reset the master frame
+        self._destroy_widget_children(master_frame)
         # Unhide the generated design frame
         self._show_gen_design()
 
@@ -1861,6 +1861,22 @@ class NewExperimentWindow(Toplevel):
         )
         self.design_tree_scroll_x.grid(row=1, column=0, sticky="ew")
         self.design_tree.configure(xscrollcommand=self.design_tree_scroll_x.set)
+
+        # Add the 'add' button to the frame but hide it for now
+        # Anything that wants to show it needs to add a command and text
+        self.tk_buttons["gen_design.add"] = ttk.Button(
+            master=self.tk_frames["gen_design.display"],
+        )
+        self.tk_buttons["gen_design.add"].grid(row=2, column=0, sticky="nsew")
+        self.tk_buttons["gen_design.add"].grid_remove()
+        # Button to close the design tree (without adding)
+        self.tk_buttons["gen_design.close"] = ttk.Button(
+            master=self.tk_frames["gen_design.display"],
+            text="Close design tree",
+            command=self._hide_gen_design,
+        )
+        self.tk_buttons["gen_design.close"].grid(row=3, column=0, sticky="nsew")
+
 
     def __read_in_generated_design(self) -> pd.DataFrame:
         # Get the design table from the treeview
@@ -1948,10 +1964,6 @@ class NewExperimentWindow(Toplevel):
         self.display_design_tree(
             design_table=dataframe_string,
         )
-        # If the add button exists, destroy it
-        if "gen_design.add" in self.tk_buttons:
-            self.tk_buttons["gen_design.add"].destroy()
-            del self.tk_buttons["gen_design.add"]
 
     def view_problem_design(self, problem_save_name: str) -> None:
         problem = self.root_problem_dict[problem_save_name]


### PR DESCRIPTION
It was originally the case that if lists were too large for the GUI to display, the lists would simply be displayed off-screen with no way for the user to access that information. I have added in vertical scrollbars for all relevant subwindows and a horizontal scrollbar to view all the generated design factors. Fixes #97.