### PR TITLE
Added Properties to Base Objects

### DIFF
--- a/simopt/base.py
+++ b/simopt/base.py
@@ -5,10 +5,35 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from enum import Enum
 from typing import Callable
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
+
+
+class ObjectiveType(Enum):
+    """Enum class for objective types."""
+
+    SINGLE = 1
+    MULTI = 2
+
+
+class ConstraintType(Enum):
+    """Enum class for constraint types."""
+
+    UNCONSTRAINED = 1
+    BOX = 2
+    DETERMINISTIC = 3
+    STOCHASTIC = 4
+
+
+class VariableType(Enum):
+    """Enum class for variable types."""
+
+    DISCRETE = 1
+    CONTINUOUS = 2
+    MIXED = 3
 
 
 class Solver(ABC):
@@ -53,19 +78,19 @@ class Solver(ABC):
 
     @property
     @abstractmethod
-    def objective_type(self) -> str:
+    def objective_type(self) -> ObjectiveType:
         """Description of objective types: "single" or "multi"."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def constraint_type(self) -> str:
+    def constraint_type(self) -> ConstraintType:
         """Description of constraints types: "unconstrained", "box", "deterministic", "stochastic"."""
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def variable_type(self) -> str:
+    def variable_type(self) -> VariableType:
         """Description of variable types: "discrete", "continuous", "mixed"."""
         raise NotImplementedError
 

--- a/simopt/base.py
+++ b/simopt/base.py
@@ -143,7 +143,9 @@ class Solver(ABC):
         """Dictionary of functions to check if a factor is permissible."""
         raise NotImplementedError
 
-    def __init__(self, name: str = "", fixed_factors: dict | None = None) -> None:
+    def __init__(
+        self, name: str = "", fixed_factors: dict | None = None
+    ) -> None:
         """Initialize a solver object.
 
         Parameters

--- a/simopt/base.py
+++ b/simopt/base.py
@@ -495,103 +495,70 @@ class Problem(ABC):
         self.__name = value
 
     @property
+    @abstractmethod
     def dim(self) -> int:
         """Number of decision variables."""
-        return self.__dim
-
-    @dim.setter
-    def dim(self, value: int) -> None:
-        self.__dim = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def n_objectives(self) -> int:
         """Number of objectives."""
-        return self.__n_objectives
-
-    @n_objectives.setter
-    def n_objectives(self, value: int) -> None:
-        self.__n_objectives = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def n_stochastic_constraints(self) -> int:
         """Number of stochastic constraints."""
-        return self.__n_stochastic_constraints
-
-    @n_stochastic_constraints.setter
-    def n_stochastic_constraints(self, value: int) -> None:
-        self.__n_stochastic_constraints = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def minmax(self) -> tuple[int]:
         """Indicators of maximization (+1) or minimization (-1) for each objective."""
-        return self.__minmax
-
-    @minmax.setter
-    def minmax(self, value: tuple[int]) -> None:
-        self.__minmax = value
+        raise NotImplementedError
 
     @property
-    def constraint_type(self) -> str:
+    @abstractmethod
+    def constraint_type(self) -> ConstraintType:
         """Description of constraints types: "unconstrained", "box", "deterministic", "stochastic"."""
-        return self.__constraint_type
-
-    @constraint_type.setter
-    def constraint_type(self, value: str) -> None:
-        self.__constraint_type = value
+        raise NotImplementedError
 
     @property
-    def variable_type(self) -> str:
+    @abstractmethod
+    def variable_type(self) -> VariableType:
         """Description of variable types: "discrete", "continuous", "mixed"."""
-        return self.__variable_type
-
-    @variable_type.setter
-    def variable_type(self, value: str) -> None:
-        self.__variable_type = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def lower_bounds(self) -> tuple:
         """Lower bound for each decision variable."""
-        return self.__lower_bounds
-
-    @lower_bounds.setter
-    def lower_bounds(self, value: tuple) -> None:
-        self.__lower_bounds = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def upper_bounds(self) -> tuple:
         """Upper bound for each decision variable."""
-        return self.__upper_bounds
-
-    @upper_bounds.setter
-    def upper_bounds(self, value: tuple) -> None:
-        self.__upper_bounds = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def gradient_available(self) -> bool:
         """True if direct gradient of objective function is available, otherwise False."""
-        return self.__gradient_available
-
-    @gradient_available.setter
-    def gradient_available(self, value: bool) -> None:
-        self.__gradient_available = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def optimal_value(self) -> float | None:
         """Optimal objective function value."""
-        return self.__optimal_value
-
-    @optimal_value.setter
-    def optimal_value(self, value: float | None) -> None:
-        self.__optimal_value = value
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def optimal_solution(self) -> tuple | None:
         """Optimal solution."""
-        return self.__optimal_solution
-
-    @optimal_solution.setter
-    def optimal_solution(self, value: tuple | None) -> None:
-        self.__optimal_solution = value
+        raise NotImplementedError
 
     @property
     def model(self) -> Model:
@@ -603,13 +570,10 @@ class Problem(ABC):
         self.__model = value
 
     @property
+    @abstractmethod
     def model_default_factors(self) -> dict:
         """Default values for overriding model-level default factors."""
-        return self.__model_default_factors
-
-    @model_default_factors.setter
-    def model_default_factors(self, value: dict) -> None:
-        self.__model_default_factors = value
+        raise NotImplementedError
 
     @property
     def model_fixed_factors(self) -> dict:
@@ -617,17 +581,16 @@ class Problem(ABC):
         return self.__model_fixed_factors
 
     @model_fixed_factors.setter
-    def model_fixed_factors(self, value: dict) -> None:
+    def model_fixed_factors(self, value: dict | None) -> None:
+        if value is None:
+            value = {}
         self.__model_fixed_factors = value
 
     @property
+    @abstractmethod
     def model_decision_factors(self) -> set[str]:
         """Set of keys for factors that are decision variables."""
-        return self.__model_decision_factors
-
-    @model_decision_factors.setter
-    def model_decision_factors(self, value: set[str]) -> None:
-        self.__model_decision_factors = value
+        raise NotImplementedError
 
     @property
     def rng_list(self) -> list[MRG32k3a]:
@@ -644,32 +607,29 @@ class Problem(ABC):
         return self.__factors
 
     @factors.setter
-    def factors(self, value: dict) -> None:
+    def factors(self, value: dict | None) -> None:
+        if value is None:
+            value = {}
         self.__factors = value
 
     @property
+    @abstractmethod
     def specifications(self) -> dict:
         """Details of each factor (for GUI, data validation, and defaults)."""
-        return self.__specifications
-
-    @specifications.setter
-    def specifications(self, value: dict) -> None:
-        self.__specifications = value
+        raise NotImplementedError
 
     @property
-    # @abstractmethod
+    @abstractmethod
     def check_factor_list(self) -> dict:
         """Dictionary of functions to check if a factor is permissible."""
-        return self.__check_factor_list
-
-    @check_factor_list.setter
-    def check_factor_list(self, value: dict) -> None:
-        self.__check_factor_list = value
+        raise NotImplementedError
 
     def __init__(
         self,
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
+        name: str,
+        fixed_factors: dict | None,
+        model_fixed_factors: dict | None,
+        model: Callable[..., Model],
     ) -> None:
         """Initialize a problem object.
 
@@ -681,24 +641,29 @@ class Problem(ABC):
             Subset of user-specified non-decision factors to pass through to the model.
 
         """
-        # Set default values for optional parameters.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set factors of the problem.
-        # Fill in missing factors with default values.
+        # Assign the name of the problem
+        self.name = name
+
+        # Add all the fixed factors to the problem
         self.factors = fixed_factors
-        for key in self.specifications:
-            if key not in fixed_factors:
-                self.factors[key] = self.specifications[key]["default"]
-        # Set subset of factors of the simulation model.
-        # Fill in missing model factors with problem-level default values.
-        for key in self.model_default_factors:
-            if key not in model_fixed_factors:
-                model_fixed_factors[key] = self.model_default_factors[key]
+        all_factors = set(self.specifications.keys())
+        present_factors = set(self.factors.keys())
+        missing_factors = all_factors - present_factors
+        for factor in missing_factors:
+            self.factors[factor] = self.specifications[factor]["default"]
+
+        # Add all the fixed factors to the model
         self.model_fixed_factors = model_fixed_factors
-        # super().__init__()
+        all_model_factors = set(self.model_default_factors.keys())
+        present_model_factors = set(self.model_fixed_factors.keys())
+        missing_model_factors = all_model_factors - present_model_factors
+        for factor in missing_model_factors:
+            self.model_fixed_factors[factor] = self.model_default_factors[
+                factor
+            ]
+
+        # Set the model
+        self.model = model(self.model_fixed_factors)
 
     def __eq__(self, other: object) -> bool:
         """Check if two problems are equivalent.

--- a/simopt/base.py
+++ b/simopt/base.py
@@ -143,7 +143,7 @@ class Solver(ABC):
         """Dictionary of functions to check if a factor is permissible."""
         raise NotImplementedError
 
-    def __init__(self, name: str, fixed_factors: dict | None = None) -> None:
+    def __init__(self, name: str = "", fixed_factors: dict | None = None) -> None:
         """Initialize a solver object.
 
         Parameters
@@ -152,6 +152,7 @@ class Solver(ABC):
             Dictionary of user-specified solver factors.
 
         """
+        assert len(name) > 0, "Name must be specified."
         self.name = name
         # Add all the fixed factors to the solver
         self.factors = fixed_factors
@@ -626,10 +627,10 @@ class Problem(ABC):
 
     def __init__(
         self,
-        name: str,
-        fixed_factors: dict | None,
-        model_fixed_factors: dict | None,
-        model: Callable[..., Model],
+        name: str = "",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+        model: Callable[..., Model] | None = None,
     ) -> None:
         """Initialize a problem object.
 
@@ -641,6 +642,9 @@ class Problem(ABC):
             Subset of user-specified non-decision factors to pass through to the model.
 
         """
+        assert len(name) > 0, "Name must be specified."
+        assert model is not None, "Model must be specified."
+
         # Assign the name of the problem
         self.name = name
 

--- a/simopt/gui/experiment_window.py
+++ b/simopt/gui/experiment_window.py
@@ -3866,8 +3866,8 @@ class PostProcessingWindow(Toplevel):
             and self.crn_across_macroreps_var.get()
             in self.crn_across_macroreps_list
             and (
-                self.meta
-                and self.n_norm_postreps_entry.get().isnumeric()
+                (self.meta
+                and self.n_norm_postreps_entry.get().isnumeric())
                 or not self.meta
             )
         ):

--- a/simopt/models/amusementpark.py
+++ b/simopt/models/amusementpark.py
@@ -7,7 +7,7 @@ A detailed description of the model/problem can be found
 from __future__ import annotations
 
 import math as math
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -53,16 +53,21 @@ class AmusementPark(Model):
 
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        """Initialize the Amusement Park Model."""
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "AMUSEMENTPARK"
-        self.n_rngs = 3
-        self.n_responses = 4
-        self.factors = fixed_factors
-        # TODO: update transition_probabilities to scale with number of attractions
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "AMUSEMENTPARK"
+
+    @property
+    def n_rngs(self) -> int:
+        return 3
+
+    @property
+    def n_responses(self) -> int:
+        return 4
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "park_capacity": {
                 "description": "The total number of tourists waiting for \
                                 attractions that can be maintained through \
@@ -126,7 +131,10 @@ class AmusementPark(Model):
             },
         }
 
-        self.check_factor_list = {
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        """Switch case for checking factor simulatability."""
+        return {
             "park_capacity": self.check_park_capacity,
             "number_attractions": self.check_number_attractions,
             "time_open": self.check_time_open,
@@ -137,7 +145,9 @@ class AmusementPark(Model):
             "erlang_shape": self.check_erlang_shape,
             "erlang_scale": self.check_erlang_scale,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     # Check for simulatable factors.

--- a/simopt/models/chessmm.py
+++ b/simopt/models/chessmm.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -51,13 +51,21 @@ class ChessMatchmaking(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "CHESS"
-        self.n_rngs = 2
-        self.n_responses = 2
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "CHESS"
+
+    @property
+    def n_rngs(self) -> int:
+        return 2
+
+    @property
+    def n_responses(self) -> int:
+        return 2
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "elo_mean": {
                 "description": "mean of normal distribution for Elo rating",
                 "datatype": float,
@@ -86,14 +94,19 @@ class ChessMatchmaking(Model):
                 "default": MAX_ALLOWABLE_DIFF,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "elo_mean": self.check_elo_mean,
             "elo_sd": self.check_elo_sd,
             "poisson_rate": self.check_poisson_rate,
             "num_players": self.check_num_players,
             "allowable_diff": self.check_allowable_diff,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_elo_mean(self) -> None:

--- a/simopt/models/cntnv.py
+++ b/simopt/models/cntnv.py
@@ -7,6 +7,8 @@ A detailed description of the model/problem can be found `here <https://simopt.r
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -44,14 +46,21 @@ class CntNV(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "CNTNEWS"
-        self.n_rngs = 1
-        self.n_responses = 1
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "CNTNEWS"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "purchase_price": {
                 "description": "purchasing cost per unit",
                 "datatype": float,
@@ -83,7 +92,10 @@ class CntNV(Model):
                 "default": 20.0,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "purchase_price": self.check_purchase_price,
             "sales_price": self.check_sales_price,
             "salvage_price": self.check_salvage_price,
@@ -91,7 +103,9 @@ class CntNV(Model):
             "Burr_c": self.check_burr_c,
             "Burr_k": self.check_burr_k,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_purchase_price(self) -> None:

--- a/simopt/models/cntnv.py
+++ b/simopt/models/cntnv.py
@@ -12,7 +12,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class CntNV(Model):
@@ -288,42 +288,57 @@ class CntNVMaxProfit(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "CNTNEWS-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 1
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.lower_bounds = (0,)
-        self.upper_bounds = (np.inf,)
-        self.gradient_available = True
-        self.optimal_value = None
-        self.optimal_solution = (
-            None  # (0.1878,)  # TO DO: Generalize to function of factors.
-        )
-        self.model_default_factors = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        # TODO: Generalize to function of factors.
+        # return (0.1878,)
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {
             "purchase_price": 5.0,
             "sales_price": 9.0,
             "salvage_price": 1.0,
             "Burr_c": 2.0,
             "Burr_k": 20.0,
         }
-        self.model_decision_factors = {"order_quantity"}
-        self.factors = fixed_factors
-        self.specifications = {
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"order_quantity"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -335,13 +350,39 @@ class CntNVMaxProfit(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = CntNV(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 1
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,)
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,)
+
+    def __init__(
+        self,
+        name: str = "CNTNEWS-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=CntNV,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/contam.py
+++ b/simopt/models/contam.py
@@ -290,7 +290,7 @@ class ContaminationTotalCostDisc(Problem):
         return 1
 
     @property
-    def n_stockastic_constraints(self) -> int:
+    def n_stochastic_constraints(self) -> int:
         return self.model.factors["stages"]
 
     @property
@@ -681,7 +681,7 @@ class ContaminationTotalCostCont(Problem):
         return 1
 
     @property
-    def n_stockastic_constraints(self) -> int:
+    def n_stochastic_constraints(self) -> int:
         return self.model.factors["stages"]
 
     @property

--- a/simopt/models/contam.py
+++ b/simopt/models/contam.py
@@ -13,7 +13,7 @@ from typing import Callable, Final
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 NUM_STAGES: Final[int] = 5
 
@@ -285,70 +285,111 @@ class ContaminationTotalCostDisc(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "CONTAM-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.minmax = (-1,)
-        self.constraint_type = "stochastic"
-        self.variable_type = "discrete"
-        self.gradient_available = True
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"prev_decision"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stockastic_constraints(self) -> int:
+        return self.model.factors["stages"]
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.STOCHASTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.DISCRETE
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"prev_decision"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
                 "default": (1,) * NUM_STAGES,
             },
             "budget": {
-                "description": "max # of replications for a solver to take.",
+                "description": "max # of replications for a solver to take",
                 "datatype": int,
                 "default": 10000,
             },
             "prev_cost": {
-                "description": "cost of prevention in each stage",
+                "description": "cost of prevention",
                 "datatype": list,
                 "default": [1] * NUM_STAGES,
             },
             "error_prob": {
-                "description": "allowable error probability in each stage",
+                "description": "error probability",
                 "datatype": list,
                 "default": [0.2] * NUM_STAGES,
             },
             "upper_thres": {
-                "description": "upper limit of amount of contamination in each stage",
+                "description": "upper limit of amount of contamination",
                 "datatype": list,
                 "default": [0.1] * NUM_STAGES,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
             "prev_cost": self.check_prev_cost,
             "error_prob": self.check_error_prob,
             "upper_thres": self.check_upper_thres,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = Contamination(self.model_fixed_factors)
-        self.dim = self.model.factors["stages"]
-        self.n_stochastic_constraints = self.model.factors["stages"]
-        self.lower_bounds = (0,) * self.model.factors["stages"]
-        self.upper_bounds = (1,) * self.model.factors["stages"]
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["stages"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.model.factors["stages"]
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (1,) * self.model.factors["stages"]
+
+    def __init__(
+        self,
+        name: str = "CONTAM-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=Contamination,
+        )
 
     def check_prev_cost(self) -> bool:
         if len(self.factors["prev_cost"]) != self.dim:
@@ -635,30 +676,49 @@ class ContaminationTotalCostCont(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "CONTAM-2",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.minmax = (-1,)
-        self.constraint_type = "stochastic"
-        self.variable_type = "continuous"
-        self.gradient_available = True
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"prev_decision"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stockastic_constraints(self) -> int:
+        return self.model.factors["stages"]
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.STOCHASTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"prev_decision"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -685,20 +745,42 @@ class ContaminationTotalCostCont(Problem):
                 "default": [0.1] * NUM_STAGES,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
             "prev_cost": self.check_prev_cost,
             "error_prob": self.check_error_prob,
             "upper_thres": self.check_upper_thres,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = Contamination(self.model_fixed_factors)
-        self.dim = self.model.factors["stages"]
-        self.n_stochastic_constraints = self.model.factors["stages"]
-        self.lower_bounds = (0,) * self.model.factors["stages"]
-        self.upper_bounds = (1,) * self.model.factors["stages"]
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["stages"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.model.factors["stages"]
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (1,) * self.model.factors["stages"]
+
+    def __init__(
+        self,
+        name: str = "CONTAM-2",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=Contamination,
+        )
 
     def check_initial_solution(self) -> bool:
         if len(self.factors["initial_solution"]) != self.dim:

--- a/simopt/models/contam.py
+++ b/simopt/models/contam.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -50,13 +50,21 @@ class Contamination(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "CONTAM"
-        self.n_rngs = 2
-        self.n_responses = 1
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "CONTAM"
+
+    @property
+    def n_rngs(self) -> int:
+        return 2
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "contam_rate_alpha": {
                 "description": "alpha parameter of beta distribution for growth rate of contamination at each stage",
                 "datatype": float,
@@ -98,7 +106,10 @@ class Contamination(Model):
                 "default": (0,) * NUM_STAGES,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "contam_rate_alpha": self.check_contam_rate_alpha,
             "contam_rate_beta": self.check_contam_rate_beta,
             "restore_rate_alpha": self.check_restore_rate_alpha,
@@ -108,7 +119,9 @@ class Contamination(Model):
             "stages": self.check_stages,
             "prev_decision": self.check_prev_decision,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_contam_rate_alpha(self) -> bool:

--- a/simopt/models/dualsourcing.py
+++ b/simopt/models/dualsourcing.py
@@ -13,7 +13,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class DualSourcing(Model):
@@ -395,34 +395,49 @@ class DualSourcingMinCost(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "DUALSOURCING-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 2
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (-1,)
-        self.constraint_type = "box"
-        self.variable_type = "discrete"
-        self.lower_bounds = (0, 0)
-        self.upper_bounds = (np.inf, np.inf)
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"order_level_exp", "order_level_reg"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.DISCRETE
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"order_level_exp", "order_level_reg"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -434,13 +449,39 @@ class DualSourcingMinCost(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = DualSourcing(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 2
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0, 0)
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf, np.inf)
+
+    def __init__(
+        self,
+        name: str = "DUALSOURCING-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=DualSourcing,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/dualsourcing.py
+++ b/simopt/models/dualsourcing.py
@@ -8,6 +8,8 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -71,14 +73,21 @@ class DualSourcing(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "DUALSOURCING"
-        self.n_rngs = 1
-        self.n_responses = 3
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "DUALSOURCING"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 3
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "n_days": {
                 "description": "number of days to simulate",
                 "datatype": int,
@@ -140,7 +149,10 @@ class DualSourcing(Model):
                 "default": 50,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "n_days": self.check_n_days,
             "initial_inv": self.check_initial_inv,
             "cost_reg": self.check_cost_reg,
@@ -154,7 +166,9 @@ class DualSourcing(Model):
             "order_level_reg": self.check_order_level_reg,
             "order_level_exp": self.check_order_level_exp,
         }
-        # Set factors of the simulation model
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     # Check for simulatable factors

--- a/simopt/models/dynamnews.py
+++ b/simopt/models/dynamnews.py
@@ -13,7 +13,7 @@ from typing import Callable, Final
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 NUM_PRODUCTS: Final[int] = 10
 
@@ -305,32 +305,49 @@ class DynamNewsMaxProfit(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "DYNAMNEWS-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_fixed_factors = {}
-        self.model_decision_factors = {"init_level"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"init_level"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -342,16 +359,39 @@ class DynamNewsMaxProfit(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = DynamNews(self.model_fixed_factors)
-        self.dim = self.model.factors["num_prod"]
-        self.lower_bounds = (0,) * self.dim
-        self.upper_bounds = (np.inf,) * self.dim
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["num_prod"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "DYNAMNEWS-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=DynamNews,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/dynamnews.py
+++ b/simopt/models/dynamnews.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -49,14 +49,21 @@ class DynamNews(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "DYNAMNEWS"
-        self.n_rngs = 1
-        self.n_responses = 4
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "DYNAMNEWS"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 4
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "num_prod": {
                 "description": "number of products",
                 "datatype": int,
@@ -93,7 +100,10 @@ class DynamNews(Model):
                 "default": [5] * NUM_PRODUCTS,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "num_prod": self.check_num_prod,
             "num_customer": self.check_num_customer,
             "c_utility": self.check_c_utility,
@@ -102,7 +112,9 @@ class DynamNews(Model):
             "price": self.check_price,
             "cost": self.check_cost,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_num_prod(self) -> bool:

--- a/simopt/models/example.py
+++ b/simopt/models/example.py
@@ -12,7 +12,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class ExampleModel(Model):
@@ -180,30 +180,62 @@ class ExampleProblem(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "EXAMPLE-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (-1,)
-        self.constraint_type = "unconstrained"
-        self.variable_type = "continuous"
-        self.gradient_available = True
-        self.model_default_factors = {}
-        self.model_fixed_factors = {}
-        self.model_decision_factors = {"x"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.UNCONSTRAINED
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        # Change if f is changed
+        # TODO: figure out what f is
+        return 0.0
+
+    @property
+    def optimal_solution(self) -> tuple:
+        # Change if f is changed
+        # TODO: figure out what f is
+        return (0,) * self.dim
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_fixed_factors(self) -> dict:
+        return {}
+
+    @model_fixed_factors.setter
+    def model_fixed_factors(self, value: dict | None) -> None:
+        # TODO: figure out if fixed factors should change
+        pass
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"x"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -215,18 +247,39 @@ class ExampleProblem(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        self.dim = len(self.factors["initial_solution"])
-        self.lower_bounds = (-np.inf,) * self.dim
-        self.upper_bounds = (np.inf,) * self.dim
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = ExampleModel(self.model_fixed_factors)
-        self.optimal_value = 0  # Change if f is changed.
-        self.optimal_solution = (0,) * self.dim  # Change if f is changed.
+
+    @property
+    def dim(self) -> int:
+        return len(self.factors["initial_solution"])
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (-np.inf,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "EXAMPLE-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=None,
+            model=ExampleModel,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/example.py
+++ b/simopt/models/example.py
@@ -7,6 +7,8 @@ evaluated with noise.
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -42,22 +44,34 @@ class ExampleModel(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "EXAMPLE"
-        self.n_rngs = 1
-        self.n_responses = 1
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "EXAMPLE"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "x": {
                 "description": "point to evaluate",
                 "datatype": tuple,
                 "default": (2.0, 2.0),
             }
         }
-        self.check_factor_list = {"x": self.check_x}
-        # Set factors of the simulation model.
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {"x": self.check_x}
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_x(self) -> bool:

--- a/simopt/models/facilitysizing.py
+++ b/simopt/models/facilitysizing.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -49,14 +49,21 @@ class FacilitySize(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "FACSIZE"
-        self.n_rngs = 1
-        self.n_responses = 3
-        # TODO: change cov and capacity to scale with number of facilities
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "FACSIZE"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 3
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "mean_vec": {
                 "description": "location parameters of the multivariate normal distribution",
                 "datatype": list,
@@ -82,13 +89,18 @@ class FacilitySize(Model):
                 "default": NUM_FACILITIES,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "mean_vec": self.check_mean_vec,
             "cov": self.check_cov,
             "capacity": self.check_capacity,
             "n_fac": self.check_n_fac,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_mean_vec(self) -> bool:

--- a/simopt/models/facilitysizing.py
+++ b/simopt/models/facilitysizing.py
@@ -13,7 +13,7 @@ from typing import Callable, Final
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 NUM_FACILITIES: Final[int] = 3
 
@@ -261,31 +261,50 @@ class FacilitySizingTotalCost(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "FACSIZE-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 1
-        self.minmax = (-1,)
-        self.constraint_type = "stochastic"
-        self.variable_type = "continuous"
-        self.gradient_available = True
-        self.optimal_value = None
-        self.optimal_solution = None  # (185, 185, 185)
-        self.model_default_factors = {}
-        self.model_decision_factors = {"capacity"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 1
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.STOCHASTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        # return (185, 185, 185)
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"capacity"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "Initial solution from which solvers start.",
                 "datatype": tuple,
@@ -307,18 +326,41 @@ class FacilitySizingTotalCost(Problem):
                 "default": 0.05,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
             "installation_costs": self.check_installation_costs,
             "epsilon": self.check_epsilon,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = FacilitySize(self.model_fixed_factors)
-        self.dim = self.model.factors["n_fac"]
-        self.lower_bounds = (0,) * self.model.factors["n_fac"]
-        self.upper_bounds = (np.inf,) * self.model.factors["n_fac"]
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["n_fac"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "FACSIZE-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=FacilitySize,
+        )
 
     def check_installation_costs(self) -> bool:
         if (
@@ -612,31 +654,50 @@ class FacilitySizingMaxService(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "FACSIZE-2",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "deterministic"
-        self.variable_type = "continuous"
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None  # (175, 179, 143)
-        self.model_default_factors = {}
-        self.model_decision_factors = {"capacity"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.DETERMINISTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        # return (175, 179, 143)
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"capacity"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "Initial solution from which solvers start.",
                 "datatype": tuple,
@@ -658,18 +719,41 @@ class FacilitySizingMaxService(Problem):
                 "default": 500.0,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
             "installation_costs": self.check_installation_costs,
             "installation_budget": self.check_installation_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = FacilitySize(self.model_fixed_factors)
-        self.dim = self.model.factors["n_fac"]
-        self.lower_bounds = (0,) * self.model.factors["n_fac"]
-        self.upper_bounds = (np.inf,) * self.model.factors["n_fac"]
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["n_fac"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "FACSIZE-2",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=FacilitySize,
+        )
 
     def check_installation_costs(self) -> bool:
         if (

--- a/simopt/models/fixedsan.py
+++ b/simopt/models/fixedsan.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -50,13 +50,21 @@ class FixedSAN(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "FIXEDSAN"
-        self.n_rngs = 1
-        self.n_responses = 1
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "FIXEDSAN"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "num_arcs": {
                 "description": "number of arcs",
                 "datatype": int,
@@ -73,12 +81,17 @@ class FixedSAN(Model):
                 "default": (1,) * NUM_ARCS,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "num_arcs": self.check_num_arcs,
             "num_nodes": self.check_num_nodes,
             "arc_means": self.check_arc_means,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_num_arcs(self) -> bool:

--- a/simopt/models/hotel.py
+++ b/simopt/models/hotel.py
@@ -13,7 +13,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class Hotel(Model):
@@ -816,31 +816,49 @@ class HotelRevenue(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "HOTEL-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "box"
-        self.variable_type = "discrete"
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"booking_limits"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.DISCRETE
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"booking_limits"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -852,17 +870,38 @@ class HotelRevenue(Problem):
                 "default": 100,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = Hotel(self.model_fixed_factors)
-        self.dim = self.model.factors["num_products"]
-        self.lower_bounds = tuple(np.zeros(self.dim))
-        self.upper_bounds = tuple(
-            self.model.factors["num_rooms"] * np.ones(self.dim)
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["num_products"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (self.model.factors["num_rooms"],) * self.dim
+
+    def __init__(
+        self,
+        name: str = "HOTEL-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=Hotel,
         )
 
     def check_initial_solution(self) -> bool:

--- a/simopt/models/hotel.py
+++ b/simopt/models/hotel.py
@@ -8,6 +8,8 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -43,13 +45,21 @@ class Hotel(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "HOTEL"
-        self.n_rngs = 1
-        self.n_responses = 1
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "HOTEL"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "num_products": {
                 "description": "number of products: (rate, length of stay)",
                 "datatype": int,
@@ -581,7 +591,10 @@ class Hotel(Model):
                 "default": tuple([100 for _ in range(56)]),
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "num_products": self.check_num_products,
             "lambda": self.check_lambda,
             "num_rooms": self.check_num_rooms,
@@ -593,7 +606,9 @@ class Hotel(Model):
             "runlength": self.check_runlength,
             "booking_limits": self.check_booking_limits,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_num_products(self) -> bool:

--- a/simopt/models/ironore.py
+++ b/simopt/models/ironore.py
@@ -18,7 +18,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class IronOre(Model):
@@ -381,39 +381,49 @@ class IronOreMaxRev(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "IRONORE-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 4
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "box"
-        self.variable_type = "mixed"
-        self.lower_bounds = (0, 0, 0, 0)
-        self.upper_bounds = (np.inf, np.inf, np.inf, np.inf)
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {
-            "price_prod",
-            "inven_stop",
-            "price_stop",
-            "price_sell",
-        }
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.MIXED
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"price_prod", "inven_stop", "price_stop", "price_sell"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -425,13 +435,39 @@ class IronOreMaxRev(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = IronOre(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 4
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "IRONORE-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=IronOre,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """
@@ -672,34 +708,49 @@ class IronOreMaxRevCnt(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "IRONORECONT-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 3
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.lower_bounds = (0.0, 0.0, 0.0)
-        self.upper_bounds = (np.inf, np.inf, np.inf)
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"price_prod", "price_stop", "price_sell"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"price_prod", "price_stop", "price_sell"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -711,13 +762,39 @@ class IronOreMaxRevCnt(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = IronOre(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 3
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0.0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "IRONORECONT-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=IronOre,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/ironore.py
+++ b/simopt/models/ironore.py
@@ -13,6 +13,7 @@ Changed get_random_solution quantiles
 from __future__ import annotations
 
 from math import copysign, sqrt
+from typing import Callable
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -52,14 +53,21 @@ class IronOre(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "IRONORE"
-        self.n_rngs = 1
-        self.n_responses = 3
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "IRONORE"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 3
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "mean_price": {
                 "description": "mean iron ore price per unit",
                 "datatype": float,
@@ -127,7 +135,9 @@ class IronOre(Model):
             },
         }
 
-        self.check_factor_list = {
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "mean_price": self.check_mean_price,
             "max_price": self.check_max_price,
             "min_price": self.check_min_price,
@@ -142,7 +152,9 @@ class IronOre(Model):
             "price_sell": self.check_price_sell,
             "n_days": self.check_n_days,
         }
-        # Set factors of the simulation model
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     # Check for simulatable factors

--- a/simopt/models/mm1queue.py
+++ b/simopt/models/mm1queue.py
@@ -8,6 +8,8 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -49,13 +51,21 @@ class MM1Queue(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "MM1"
-        self.n_rngs = 2
-        self.n_responses = 3
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "MM1"
+
+    @property
+    def n_rngs(self) -> int:
+        return 2
+
+    @property
+    def n_responses(self) -> int:
+        return 3
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "lambda": {
                 "description": "rate parameter of interarrival time distribution",
                 "datatype": float,
@@ -82,14 +92,19 @@ class MM1Queue(Model):
                 "default": 50,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "lambda": self.check_lambda,
             "mu": self.check_mu,
             "epsilon": self.check_epsilon,
             "warmup": self.check_warmup,
             "people": self.check_people,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_lambda(self) -> bool:

--- a/simopt/models/mm1queue.py
+++ b/simopt/models/mm1queue.py
@@ -13,7 +13,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class MM1Queue(Model):
@@ -315,34 +315,49 @@ class MM1MinMeanSojournTime(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "MM1-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 1
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (-1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.lower_bounds = (0,)
-        self.upper_bounds = (np.inf,)
-        self.gradient_available = True
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {"warmup": 50, "people": 200}
-        self.model_decision_factors = {"mu"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {"warmup": 50, "people": 200}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"mu"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution from which solvers start",
                 "datatype": tuple,
@@ -359,13 +374,39 @@ class MM1MinMeanSojournTime(Problem):
                 "default": 0.1,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = MM1Queue(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 1
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "MM1-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=MM1Queue,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/network.py
+++ b/simopt/models/network.py
@@ -13,7 +13,7 @@ from typing import Callable, Final
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 NUM_NETWORKS: Final = 10
 
@@ -378,31 +378,49 @@ class NetworkMinTotalCost(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "NETWORK-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (-1,)
-        self.constraint_type = "deterministic"
-        self.variable_type = "continuous"
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"process_prob"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.DETERMINISTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"process_prob"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -414,19 +432,38 @@ class NetworkMinTotalCost(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = Network(self.model_fixed_factors)
-        self.dim = self.model.factors["n_networks"]
-        self.lower_bounds = tuple(
-            [0 for _ in range(self.model.factors["n_networks"])]
-        )
-        self.upper_bounds = tuple(
-            [1 for _ in range(self.model.factors["n_networks"])]
+
+    @property
+    def dim(self) -> int:
+        return self.model.factors["n_networks"]
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (1,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "NETWORK-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=Network,
         )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:

--- a/simopt/models/network.py
+++ b/simopt/models/network.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -47,14 +47,21 @@ class Network(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "NETWORK"
-        self.n_rngs = 3
-        self.n_responses = 1
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "NETWORK"
+
+    @property
+    def n_rngs(self) -> int:
+        return 3
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "process_prob": {
                 "description": "probability that a message will go through a particular network i",
                 "datatype": list,
@@ -102,7 +109,9 @@ class Network(Model):
             },
         }
 
-        self.check_factor_list = {
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "process_prob": self.check_process_prob,
             "cost_process": self.check_cost_process,
             "cost_time": self.check_cost_time,
@@ -113,7 +122,9 @@ class Network(Model):
             "n_messages": self.check_n_messages,
             "n_networks": self.check_n_networks,
         }
-        # Set factors of the simulation model
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     # Check for simulatable factors

--- a/simopt/models/paramesti.py
+++ b/simopt/models/paramesti.py
@@ -247,7 +247,8 @@ class ParamEstiMaxLogLik(Problem):
     @property
     def optimal_solution(self) -> tuple | None:
         solution = self.model.factors["xstar"]
-        assert isinstance(solution, (tuple, type(None)))
+        if isinstance(solution, list):
+            return tuple(solution)
         return solution
 
     @property

--- a/simopt/models/paramesti.py
+++ b/simopt/models/paramesti.py
@@ -9,6 +9,7 @@ A detailed description of the model/problem can be found
 from __future__ import annotations
 
 import math
+from typing import Callable
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -46,13 +47,21 @@ class ParameterEstimation(Model):
     base.model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "PARAMESTI"
-        self.n_rngs = 2
-        self.n_responses = 1
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "PARAMESTI"
+
+    @property
+    def n_rngs(self) -> int:
+        return 2
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "xstar": {
                 "description": "x^*, the unknown parameter that maximizes g(x)",
                 "datatype": list,
@@ -64,8 +73,13 @@ class ParameterEstimation(Model):
                 "default": [1, 1],
             },
         }
-        self.check_factor_list = {"xstar": self.check_xstar, "x": self.check_x}
-        # Set factors of the simulation model.
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {"xstar": self.check_xstar, "x": self.check_x}
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_xstar(self) -> bool:

--- a/simopt/models/paramesti.py
+++ b/simopt/models/paramesti.py
@@ -14,7 +14,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class ParameterEstimation(Model):
@@ -216,32 +216,51 @@ class ParamEstiMaxLogLik(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "PARAMESTI-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 2
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.lower_bounds = (0.1, 0.1)
-        self.upper_bounds = (10, 10)
-        self.gradient_available = False
-        self.model_default_factors = {}
-        self.model_decision_factors = {"x"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        solution = self.model.factors["xstar"]
+        assert isinstance(solution, (tuple, type(None)))
+        return solution
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"x"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": list,
@@ -253,15 +272,39 @@ class ParamEstiMaxLogLik(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = ParameterEstimation(self.model_fixed_factors)
-        self.optimal_solution: list = self.model.factors["xstar"]
-        self.optimal_value = None
+
+    @property
+    def dim(self) -> int:
+        return 2
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0.1,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (10,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "PARAMESTI-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=ParameterEstimation,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/rmitd.py
+++ b/simopt/models/rmitd.py
@@ -14,7 +14,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class RMITD(Model):
@@ -322,34 +322,50 @@ class RMITDMaxRevenue(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "RMITD-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 3
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "deterministic"
-        self.variable_type = "discrete"
-        self.lower_bounds = (0, 0, 0)
-        self.upper_bounds = (np.inf, np.inf, np.inf)
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None  # (90, 50, 0)
-        self.model_default_factors = {}
-        self.model_decision_factors = {"initial_inventory", "reservation_qtys"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.DETERMINISTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.DISCRETE
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        # return (90, 50, 0)
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"initial_inventory", "reservation_qtys"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -361,13 +377,39 @@ class RMITDMaxRevenue(Problem):
                 "default": 10000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = RMITD(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 3
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "RMITD-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=RMITD,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/rmitd.py
+++ b/simopt/models/rmitd.py
@@ -9,6 +9,8 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -46,13 +48,21 @@ class RMITD(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "RMITD"
-        self.n_rngs = 2
-        self.n_responses = 1
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "RMITD"
+
+    @property
+    def n_rngs(self) -> int:
+        return 2
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "time_horizon": {
                 "description": "time horizon",
                 "datatype": int,
@@ -94,7 +104,10 @@ class RMITD(Model):
                 "default": [50, 30],
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "time_horizon": self.check_time_horizon,
             "prices": self.check_prices,
             "demand_means": self.check_demand_means,
@@ -104,7 +117,9 @@ class RMITD(Model):
             "initial_inventory": self.check_initial_inventory,
             "reservation_qtys": self.check_reservation_qtys,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_time_horizon(self) -> bool:

--- a/simopt/models/san.py
+++ b/simopt/models/san.py
@@ -8,7 +8,7 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Callable, Final
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -49,13 +49,21 @@ class SAN(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "SAN"
-        self.n_rngs = 1
-        self.n_responses = 1
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "SAN"
+
+    @property
+    def n_rngs(self) -> int:
+        return 1
+
+    @property
+    def n_responses(self) -> int:
+        return 1
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "num_nodes": {
                 "description": "number of nodes",
                 "datatype": int,
@@ -86,12 +94,17 @@ class SAN(Model):
                 "default": (1,) * NUM_ARCS,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "num_nodes": self.check_num_nodes,
             "arcs": self.check_arcs,
             "arc_means": self.check_arc_means,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     def check_num_nodes(self) -> bool:

--- a/simopt/models/san.py
+++ b/simopt/models/san.py
@@ -13,7 +13,7 @@ from typing import Callable, Final
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 NUM_ARCS: Final[int] = 13
 
@@ -314,31 +314,49 @@ class SANLongestPath(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "SAN-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (-1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_available = True
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"arc_means"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return True
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"arc_means"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -355,17 +373,40 @@ class SANLongestPath(Problem):
                 "default": (1,) * NUM_ARCS,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
             "arc_costs": self.check_arc_costs,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and over-riden defaults.
-        self.model = SAN(self.model_fixed_factors)
-        self.dim = len(self.model.factors["arcs"])
-        self.lower_bounds = (1e-2,) * self.dim
-        self.upper_bounds = (np.inf,) * self.dim
+
+    @property
+    def dim(self) -> int:
+        return len(self.model.factors["arcs"])
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (1e-2,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "SAN-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=SAN,
+        )
 
     def check_arc_costs(self) -> bool:
         positive = True

--- a/simopt/models/sscont.py
+++ b/simopt/models/sscont.py
@@ -10,6 +10,7 @@ A detailed description of the model/problem can be found
 from __future__ import annotations
 
 from math import sqrt
+from typing import Callable
 
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
@@ -71,14 +72,21 @@ class SSCont(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "SSCONT"
-        self.n_rngs = 2
-        self.n_responses = 7
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "SSCONT"
+
+    @property
+    def n_rngs(self) -> int:
+        return 2
+
+    @property
+    def n_responses(self) -> int:
+        return 7
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "demand_mean": {
                 "description": "mean of exponentially distributed demand in each period",
                 "datatype": float,
@@ -130,7 +138,10 @@ class SSCont(Model):
                 "default": 20,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "demand_mean": self.check_demand_mean,
             "lead_mean": self.check_lead_mean,
             "backorder_cost": self.check_backorder_cost,
@@ -142,7 +153,9 @@ class SSCont(Model):
             "n_days": self.check_n_days,
             "warmup": self.check_warmup,
         }
-        # Set factors of the simulation model.
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     # Check for simulatable factors

--- a/simopt/models/sscont.py
+++ b/simopt/models/sscont.py
@@ -15,7 +15,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class SSCont(Model):
@@ -435,34 +435,49 @@ class SSContMinCost(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "SSCONT-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 2
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (-1,)
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.lower_bounds = (0, 0)
-        self.upper_bounds = (np.inf, np.inf)
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {"demand_mean": 100.0, "lead_mean": 6.0}
-        self.model_decision_factors = {"s", "S"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (-1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {"demand_mean": 100.0, "lead_mean": 6.0}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"s", "S"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution from which solvers start",
                 "datatype": tuple,
@@ -474,13 +489,39 @@ class SSContMinCost(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = SSCont(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 2
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "SSCONT-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=SSCont,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/tableallocation.py
+++ b/simopt/models/tableallocation.py
@@ -13,7 +13,7 @@ from typing import Callable
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
-from simopt.base import Model, Problem
+from simopt.base import ConstraintType, Model, Problem, VariableType
 
 
 class TableAllocation(Model):
@@ -331,34 +331,49 @@ class TableAllocationMaxRev(Problem):
     base.Problem
     """
 
-    def __init__(
-        self,
-        name: str = "TABLEALLOCATION-1",
-        fixed_factors: dict | None = None,
-        model_fixed_factors: dict | None = None,
-    ) -> None:
-        # Handle default arguments.
-        if fixed_factors is None:
-            fixed_factors = {}
-        if model_fixed_factors is None:
-            model_fixed_factors = {}
-        # Set problem attributes.
-        self.name = name
-        self.dim = 4
-        self.n_objectives = 1
-        self.n_stochastic_constraints = 0
-        self.minmax = (1,)
-        self.constraint_type = "deterministic"
-        self.variable_type = "discrete"
-        self.lower_bounds = (0, 0, 0, 0)
-        self.upper_bounds = (np.inf, np.inf, np.inf, np.inf)
-        self.gradient_available = False
-        self.optimal_value = None
-        self.optimal_solution = None
-        self.model_default_factors = {}
-        self.model_decision_factors = {"num_tables"}
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def n_objectives(self) -> int:
+        return 1
+
+    @property
+    def n_stochastic_constraints(self) -> int:
+        return 0
+
+    @property
+    def minmax(self) -> tuple[int]:
+        return (1,)
+
+    @property
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.DETERMINISTIC
+
+    @property
+    def variable_type(self) -> VariableType:
+        return VariableType.DISCRETE
+
+    @property
+    def gradient_available(self) -> bool:
+        return False
+
+    @property
+    def optimal_value(self) -> float | None:
+        return None
+
+    @property
+    def optimal_solution(self) -> tuple | None:
+        return None
+
+    @property
+    def model_default_factors(self) -> dict:
+        return {}
+
+    @property
+    def model_decision_factors(self) -> set[str]:
+        return {"num_tables"}
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "initial_solution": {
                 "description": "initial solution",
                 "datatype": tuple,
@@ -370,13 +385,39 @@ class TableAllocationMaxRev(Problem):
                 "default": 1000,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "initial_solution": self.check_initial_solution,
             "budget": self.check_budget,
         }
-        super().__init__(fixed_factors, model_fixed_factors)
-        # Instantiate model with fixed factors and overwritten defaults.
-        self.model = TableAllocation(self.model_fixed_factors)
+
+    @property
+    def dim(self) -> int:
+        return 4
+
+    @property
+    def lower_bounds(self) -> tuple:
+        return (0,) * self.dim
+
+    @property
+    def upper_bounds(self) -> tuple:
+        return (np.inf,) * self.dim
+
+    def __init__(
+        self,
+        name: str = "TABLEALLOCATION-1",
+        fixed_factors: dict | None = None,
+        model_fixed_factors: dict | None = None,
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(
+            name=name,
+            fixed_factors=fixed_factors,
+            model_fixed_factors=model_fixed_factors,
+            model=TableAllocation,
+        )
 
     def vector_to_factor_dict(self, vector: tuple) -> dict:
         """

--- a/simopt/models/tableallocation.py
+++ b/simopt/models/tableallocation.py
@@ -8,6 +8,8 @@ A detailed description of the model/problem can be found
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from mrg32k3a.mrg32k3a import MRG32k3a
 
@@ -60,14 +62,21 @@ class TableAllocation(Model):
     base.Model
     """
 
-    def __init__(self, fixed_factors: dict | None = None) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = "TABLEALLOCATION"
-        self.n_rngs = 3
-        self.n_responses = 2
-        self.factors = fixed_factors
-        self.specifications = {
+    @property
+    def name(self) -> str:
+        return "TABLEALLOCATION"
+
+    @property
+    def n_rngs(self) -> int:
+        return 3
+
+    @property
+    def n_responses(self) -> int:
+        return 2
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "n_hours": {
                 "description": "number of hours to simulate",
                 "datatype": float,
@@ -104,7 +113,10 @@ class TableAllocation(Model):
                 "default": [10, 5, 4, 2],
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "n_hours": self.check_n_hours,
             "capacity": self.check_capacity,
             "table_cap": self.check_table_cap,
@@ -113,7 +125,9 @@ class TableAllocation(Model):
             "table_revenue": self.check_table_revenue,
             "num_tables": self.check_num_tables,
         }
-        # Set factors of the simulation model
+
+    def __init__(self, fixed_factors: dict | None = None) -> None:
+        # Let the base class handle default arguments.
         super().__init__(fixed_factors)
 
     # Check for simulatable factors

--- a/simopt/solvers/adam.py
+++ b/simopt/solvers/adam.py
@@ -13,7 +13,14 @@ from typing import Callable
 
 import numpy as np
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class ADAM(Solver):
@@ -56,16 +63,16 @@ class ADAM(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "box"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
 
     @property
-    def variable_type(self) -> str:
-        return "continuous"
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
 
     @property
     def gradient_needed(self) -> bool:

--- a/simopt/solvers/adam.py
+++ b/simopt/solvers/adam.py
@@ -9,6 +9,8 @@ A detailed description of the solver can be found `here <https://simopt.readthed
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 
 from simopt.base import Problem, Solution, Solver
@@ -53,17 +55,25 @@ class ADAM(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "ADAM", fixed_factors: dict | None = None
-    ) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "box"
+
+    @property
+    def variable_type(self) -> str:
+        return "continuous"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions?",
                 "datatype": bool,
@@ -100,7 +110,10 @@ class ADAM(Solver):
                 "default": 10 ** (-7),
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "crn_across_solns": self.check_crn_across_solns,
             "r": self.check_r,
             "beta_1": self.check_beta_1,
@@ -109,7 +122,12 @@ class ADAM(Solver):
             "epsilon": self.check_epsilon,
             "sensitivity": self.check_sensitivity,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "ADAM", fixed_factors: dict | None = None
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_r(self) -> None:
         if self.factors["r"] <= 0:

--- a/simopt/solvers/aloe.py
+++ b/simopt/solvers/aloe.py
@@ -15,7 +15,14 @@ from typing import Callable
 import numpy as np
 from numpy.linalg import norm
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class ALOE(Solver):
@@ -57,16 +64,16 @@ class ALOE(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "box"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
 
     @property
-    def variable_type(self) -> str:
-        return "continuous"
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
 
     @property
     def gradient_needed(self) -> bool:

--- a/simopt/solvers/aloe.py
+++ b/simopt/solvers/aloe.py
@@ -10,6 +10,8 @@ A detailed description of the solver can be found `here <https://simopt.readthed
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 from numpy.linalg import norm
 
@@ -54,17 +56,25 @@ class ALOE(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "ALOE", fixed_factors: dict | None = None
-    ) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "box"
+
+    @property
+    def variable_type(self) -> str:
+        return "continuous"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions?",
                 "datatype": bool,
@@ -111,7 +121,10 @@ class ALOE(Solver):
                 "default": 2,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "crn_across_solns": self.check_crn_across_solns,
             "r": self.check_r,
             "theta": self.check_theta,
@@ -122,7 +135,12 @@ class ALOE(Solver):
             "sensitivity": self.check_sensitivity,
             "lambda": self.check_lambda,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "ALOE", fixed_factors: dict | None = None
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_r(self) -> None:
         if self.factors["r"] <= 0:

--- a/simopt/solvers/astrodf.py
+++ b/simopt/solvers/astrodf.py
@@ -21,7 +21,14 @@ import numpy as np
 from numpy.linalg import norm, pinv
 from scipy.optimize import NonlinearConstraint, minimize
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class ASTRODF(Solver):
@@ -61,16 +68,16 @@ class ASTRODF(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "box"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
 
     @property
-    def variable_type(self) -> str:
-        return "continuous"
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
 
     @property
     def gradient_needed(self) -> bool:

--- a/simopt/solvers/astrodf.py
+++ b/simopt/solvers/astrodf.py
@@ -60,26 +60,25 @@ class ASTRODF(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "ASTRODF", fixed_factors: dict | None = None
-    ) -> None:
-        """
-        Initialize the ASTRO-DF solver.
-        Arguments
-        ---------
-        name : str
-            user-specified name for solver
-        fixed_factors : dict
-            fixed_factors of the solver
-        """
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "box"
+
+    @property
+    def variable_type(self) -> str:
+        return "continuous"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions",
                 "datatype": bool,
@@ -126,8 +125,10 @@ class ASTRODF(Solver):
                 "default": 0.1,
             },
         }
-        # TODO: fix so we don't have to type ignore the check_crn_across_solns
-        self.check_factor_list: dict[str, Callable[[], None]] = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "crn_across_solns": self.check_crn_across_solns,  # type: ignore
             "eta_1": self.check_eta_1,
             "eta_2": self.check_eta_2,
@@ -136,7 +137,21 @@ class ASTRODF(Solver):
             "lambda_min": self.check_lambda_min,
             "ps_sufficient_reduction": self.check_ps_sufficient_reduction,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "ASTRODF", fixed_factors: dict | None = None
+    ) -> None:
+        """
+        Initialize the ASTRO-DF solver.
+        Arguments
+        ---------
+        name : str
+            user-specified name for solver
+        fixed_factors : dict
+            fixed_factors of the solver
+        """
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_eta_1(self) -> None:
         if self.factors["eta_1"] <= 0:

--- a/simopt/solvers/neldmd.py
+++ b/simopt/solvers/neldmd.py
@@ -14,7 +14,14 @@ from typing import Callable
 
 import numpy as np
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class NelderMead(Solver):
@@ -57,16 +64,16 @@ class NelderMead(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "box"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
 
     @property
-    def variable_type(self) -> str:
-        return "continuous"
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
 
     @property
     def gradient_needed(self) -> bool:

--- a/simopt/solvers/neldmd.py
+++ b/simopt/solvers/neldmd.py
@@ -10,6 +10,8 @@ A detailed description of the solver can be found
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 
 from simopt.base import Problem, Solution, Solver
@@ -54,17 +56,25 @@ class NelderMead(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "NELDMD", fixed_factors: dict | None = None
-    ) -> None:
-        if fixed_factors is None:
-            fixed_factors = {}
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "box"
+
+    @property
+    def variable_type(self) -> str:
+        return "continuous"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions?",
                 "datatype": bool,
@@ -106,7 +116,10 @@ class NelderMead(Solver):
                 "default": 1 / 10,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "crn_across_solns": self.check_crn_across_solns,
             "r": self.check_r,
             "alpha": self.check_alpha,
@@ -116,7 +129,12 @@ class NelderMead(Solver):
             "sensitivity": self.check_sensitivity,
             "initial_spread": self.check_initial_spread,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "NELDMD", fixed_factors: dict | None = None
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_r(self) -> None:
         if self.factors["r"] <= 0:

--- a/simopt/solvers/randomsearch.py
+++ b/simopt/solvers/randomsearch.py
@@ -8,6 +8,8 @@ A detailed description of the solver can be found `here <https://simopt.readthed
 
 from __future__ import annotations
 
+from typing import Callable
+
 from simopt.base import Problem, Solution, Solver
 
 
@@ -50,15 +52,25 @@ class RandomSearch(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "RNDSRCH", fixed_factors: dict | None = None
-    ) -> None:
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "stochastic"
-        self.variable_type = "mixed"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "stochastic"
+
+    @property
+    def variable_type(self) -> str:
+        return "mixed"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions?",
                 "datatype": bool,
@@ -70,11 +82,19 @@ class RandomSearch(Solver):
                 "default": 10,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "crn_across_solns": self.check_crn_across_solns,
             "sample_size": self.check_sample_size,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "RNDSRCH", fixed_factors: dict | None = None
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_sample_size(self) -> None:
         if self.factors["sample_size"] <= 0:

--- a/simopt/solvers/randomsearch.py
+++ b/simopt/solvers/randomsearch.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 
 from typing import Callable
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class RandomSearch(Solver):
@@ -53,16 +60,16 @@ class RandomSearch(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "stochastic"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.STOCHASTIC
 
     @property
-    def variable_type(self) -> str:
-        return "mixed"
+    def variable_type(self) -> VariableType:
+        return VariableType.MIXED
 
     @property
     def gradient_needed(self) -> bool:

--- a/simopt/solvers/spsa.py
+++ b/simopt/solvers/spsa.py
@@ -7,6 +7,7 @@ Simultaneous perturbation stochastic approximation (SPSA) is an algorithm for op
 from __future__ import annotations
 
 import sys
+from typing import Callable
 
 import numpy as np
 
@@ -51,15 +52,25 @@ class SPSA(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "SPSA", fixed_factors: dict | None = None
-    ) -> None:
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "box"
+
+    @property
+    def variable_type(self) -> str:
+        return "continuous"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions?",
                 "datatype": bool,
@@ -106,7 +117,10 @@ class SPSA(Solver):
                 "default": 0.1,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "alpha": self.check_alpha,
             "gamma": self.check_gamma,
             "step": self.check_step,
@@ -116,7 +130,12 @@ class SPSA(Solver):
             "eval_pct": self.check_eval_pct,
             "iter_pct": self.check_iter_pct,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "SPSA", fixed_factors: dict | None = None
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_alpha(self) -> None:
         if self.factors["alpha"] <= 0:

--- a/simopt/solvers/spsa.py
+++ b/simopt/solvers/spsa.py
@@ -11,7 +11,14 @@ from typing import Callable
 
 import numpy as np
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class SPSA(Solver):
@@ -53,16 +60,16 @@ class SPSA(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "box"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
 
     @property
-    def variable_type(self) -> str:
-        return "continuous"
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
 
     @property
     def gradient_needed(self) -> bool:

--- a/simopt/solvers/strong.py
+++ b/simopt/solvers/strong.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import math
 import sys
-from typing import Literal
+from typing import Callable, Literal
 
 import numpy as np
 from numpy.linalg import norm
@@ -57,15 +57,25 @@ class STRONG(Solver):
     base.Solver
     """
 
-    def __init__(
-        self, name: str = "STRONG", fixed_factors: dict | None = None
-    ) -> None:
-        self.name = name
-        self.objective_type = "single"
-        self.constraint_type = "box"
-        self.variable_type = "continuous"
-        self.gradient_needed = False
-        self.specifications = {
+    @property
+    def objective_type(self) -> str:
+        return "single"
+
+    @property
+    def constraint_type(self) -> str:
+        return "box"
+
+    @property
+    def variable_type(self) -> str:
+        return "continuous"
+
+    @property
+    def gradient_needed(self) -> bool:
+        return False
+
+    @property
+    def specifications(self) -> dict[str, dict]:
+        return {
             "crn_across_solns": {
                 "description": "use CRN across solutions?",
                 "datatype": bool,
@@ -127,7 +137,10 @@ class STRONG(Solver):
                 "default": 1.01,
             },
         }
-        self.check_factor_list = {
+
+    @property
+    def check_factor_list(self) -> dict[str, Callable]:
+        return {
             "crn_across_solns": self.check_crn_across_solns,
             "n_r": self.check_n_r,
             "sensitivity": self.check_sensitivity,
@@ -139,7 +152,12 @@ class STRONG(Solver):
             "gamma_2": self.check_gamma_2,
             "lambda": self.check_lambda,
         }
-        super().__init__(fixed_factors)
+
+    def __init__(
+        self, name: str = "STRONG", fixed_factors: dict | None = None
+    ) -> None:
+        # Let the base class handle default arguments.
+        super().__init__(name, fixed_factors)
 
     def check_n_r(self) -> bool:
         return self.factors["n_r"] > 0

--- a/simopt/solvers/strong.py
+++ b/simopt/solvers/strong.py
@@ -16,7 +16,14 @@ from typing import Callable, Literal
 import numpy as np
 from numpy.linalg import norm
 
-from simopt.base import Problem, Solution, Solver
+from simopt.base import (
+    ConstraintType,
+    ObjectiveType,
+    Problem,
+    Solution,
+    Solver,
+    VariableType,
+)
 
 
 class STRONG(Solver):
@@ -58,16 +65,16 @@ class STRONG(Solver):
     """
 
     @property
-    def objective_type(self) -> str:
-        return "single"
+    def objective_type(self) -> ObjectiveType:
+        return ObjectiveType.SINGLE
 
     @property
-    def constraint_type(self) -> str:
-        return "box"
+    def constraint_type(self) -> ConstraintType:
+        return ConstraintType.BOX
 
     @property
-    def variable_type(self) -> str:
-        return "continuous"
+    def variable_type(self) -> VariableType:
+        return VariableType.CONTINUOUS
 
     @property
     def gradient_needed(self) -> bool:


### PR DESCRIPTION
Instead of having the values for attributes set in the `__init__` functions of base objects (Problems/Solvers/Models), each base object now has properties that set those attributes. This protects constant attributes from being changed and cleans up the `__init__` functions. Making required properties abstract will also ensure any future base objects don't forget to implement them.