### PR TITLE
Fix Unhashable List Error

### DIFF
--- a/simopt/experiment_base.py
+++ b/simopt/experiment_base.py
@@ -2860,21 +2860,18 @@ def check_common_problem_and_reference(
         raise TypeError(error_msg)
 
     problem_list = [experiment.problem for experiment in experiments]
-    if len(set(problem_list)) != 1:
-        raise ValueError(
-            "At least two experiments have different problem instances."
-        )
+    problem_err_msg = "All experiments must have the same problem."
+    assert all(
+        elem == problem_list[0] for elem in problem_list
+    ), problem_err_msg
+
     x0_list = [experiment.x0 for experiment in experiments]
-    if len(set(x0_list)) != 1:
-        raise ValueError(
-            "At least two experiments have different starting solutions."
-        )
+    x0_err_msg = "All experiments must have the same starting solution."
+    assert all(elem == x0_list[0] for elem in x0_list), x0_err_msg
+
     xstar_list = [experiment.xstar for experiment in experiments]
-    if len(set(xstar_list)) != 1:
-        raise ValueError(
-            "At least two experiments have different optimal solutions."
-        )
-    return
+    xstar_err_msg = "All experiments must have the same optimal solution."
+    assert all(elem == xstar_list[0] for elem in xstar_list), xstar_err_msg
 
 
 def plot_progress_curves(


### PR DESCRIPTION
The `check_common_problem_and_reference` previously tried to determine if all problems/references were common by creating a set of the objects and checking the size of the set. Since sets cannot contain duplicate items, any size greater than 1 would mean that the problem/reference was not the same.

However, it seems that there is some issue in the way that hashing works for Problems, Models, and/or Solvers as the hash functions were crashing while trying to hash lists. This issue was fixed by simply checking that each element in the list is equivalent to the first element. This does not present any issues as the `=` operator works correctly for all datatypes.