### PR TITLE
Fix Broken Python <3.10 Compatibility

### DIFF
--- a/simopt/data_farming_base.py
+++ b/simopt/data_farming_base.py
@@ -366,7 +366,7 @@ class DataFarmingExperiment:
 
         """
         # Type checking
-        if not isinstance(csv_filename, (str | os.PathLike)):
+        if not isinstance(csv_filename, (str, os.PathLike)):
             error_msg = "csv_filename must be a string or path-like object."
             raise TypeError(error_msg)
 

--- a/simopt/gui/df_object.py
+++ b/simopt/gui/df_object.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from abc import ABC, abstractmethod
 from tkinter import ttk
-from typing import Literal
+from typing import Literal, Union
 
 
 class DFFactor(ABC):
@@ -41,12 +41,14 @@ class DFFactor(ABC):
         raise NotImplementedError
 
     @property
-    def include(self) -> tk.BooleanVar | None:
+    def include(self) -> Union[tk.BooleanVar, None]:
         """Whether to include the factor in the experiment."""
         return None
 
     @property
-    def include_default_state(self) -> Literal["normal", "readonly", "disabled", None]:
+    def include_default_state(
+        self,
+    ) -> Literal["normal", "readonly", "disabled", None]:
         """Whether or not the default field is enabled."""
         if self.include is None:
             return None
@@ -55,7 +57,9 @@ class DFFactor(ABC):
         return "normal"
 
     @property
-    def include_datafarm_state(self) -> Literal["normal", "readonly", "disabled", None]:
+    def include_datafarm_state(
+        self,
+    ) -> Literal["normal", "readonly", "disabled", None]:
         """Whether or not the datafarm fields are enabled."""
         if self.include is None:
             return None
@@ -64,17 +68,17 @@ class DFFactor(ABC):
         return "disabled"
 
     @property
-    def minimum(self) -> tk.IntVar | tk.DoubleVar | None:
+    def minimum(self) -> Union[tk.IntVar, tk.DoubleVar, None]:
         """The minimum value of the factor."""
         return None
 
     @property
-    def maximum(self) -> tk.IntVar | tk.DoubleVar | None:
+    def maximum(self) -> Union[tk.IntVar, tk.DoubleVar, None]:
         """The maximum value of the factor."""
         return None
 
     @property
-    def num_decimals(self) -> tk.IntVar | None:
+    def num_decimals(self) -> Union[tk.IntVar, None]:
         """The number of decimals of the factor."""
         return None
 
@@ -186,7 +190,9 @@ class DFFactor(ABC):
             )
         return self.ent_default
 
-    def get_include_checkbutton(self, frame: ttk.Frame) -> tk.Checkbutton | None:
+    def get_include_checkbutton(
+        self, frame: ttk.Frame
+    ) -> Union[tk.Checkbutton, None]:
         """Get the include checkbutton of the factor.
 
         Parameters
@@ -210,7 +216,7 @@ class DFFactor(ABC):
             )
         return self.chk_include
 
-    def get_minimum_entry(self, frame: ttk.Frame) -> ttk.Entry | None:
+    def get_minimum_entry(self, frame: ttk.Frame) -> Union[ttk.Entry, None]:
         """Get the minimum entry of the factor.
 
         Parameters
@@ -236,7 +242,7 @@ class DFFactor(ABC):
             )
         return self.ent_minimum
 
-    def get_maximum_entry(self, frame: ttk.Frame) -> ttk.Entry | None:
+    def get_maximum_entry(self, frame: ttk.Frame) -> Union[ttk.Entry, None]:
         """Get the maximum entry of the factor.
 
         Parameters
@@ -262,7 +268,9 @@ class DFFactor(ABC):
             )
         return self.ent_maximum
 
-    def get_num_decimals_entry(self, frame: ttk.Frame) -> ttk.Entry | None:
+    def get_num_decimals_entry(
+        self, frame: ttk.Frame
+    ) -> Union[ttk.Entry, None]:
         """Get the number of decimals entry of the factor.
 
         Parameters
@@ -341,7 +349,7 @@ class DFBoolean(DFFactor):
     def default_eval(self) -> bool:
         """Evaluated default value of the factor."""
         return self.default.get()
-    
+
     @property
     def include_default_state(self) -> Literal["readonly", "disabled", None]:
         """Whether or not the default field is enabled."""
@@ -359,7 +367,6 @@ class DFBoolean(DFFactor):
         if self.include.get():
             return "readonly"
         return "disabled"
-
 
     def __init__(self, name: str, description: str, default: bool) -> None:
         """Initialize the boolean factor class.
@@ -404,7 +411,7 @@ class DFBoolean(DFFactor):
             )
             self.ent_default.current(0 if self.default.get() else 1)
         return self.ent_default
-    
+
     def _toggle_fields(self) -> None:
         super()._toggle_fields()
         if self.ent_default.state() != ["disabled"]:
@@ -589,7 +596,7 @@ class DFFloat(DFFactor):
             return int(str(value).split("e-")[1])
         # Case 3: No decimal point and not in xe-y format
         return 0
-        
+
 
 class DFTuple(DFFactor):
     """Class to store tuple factors for problems and solvers."""
@@ -685,7 +692,7 @@ class DFList(DFFactor):
         self.__default = tk.StringVar(value=str(default))
 
 
-def spec_dict_to_df_dict(spec_dict: dict[str, dict]) -> dict[str, DFFactor]:
+def spec_dict_to_df_dict(spec_dict: "dict[str, dict]") -> "dict[str, DFFactor]":
     """Convert a dictionary of specifications to a dictionary of datafarm factors.
 
     Parameters

--- a/simopt/gui/new_experiment_window.py
+++ b/simopt/gui/new_experiment_window.py
@@ -5,7 +5,7 @@ import tkinter as tk
 from abc import ABCMeta
 from tkinter import filedialog, messagebox, ttk
 from tkinter.font import nametofont
-from typing import Callable, Final, Literal
+from typing import Callable, Final, Literal, Union
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -942,14 +942,14 @@ class NewExperimentWindow(Toplevel):
         )
 
     def add_problem_to_curr_exp(
-        self, unique_name: str, problem_list: list[list]
+        self, unique_name: str, problem_list: "list[list]"
     ) -> None:
         self.root_problem_dict[unique_name] = problem_list
         self.add_problem_to_curr_exp_list(unique_name)
         self.__update_solver_dropdown()
 
     def add_solver_to_curr_exp(
-        self, unique_name: str, solver_list: list[list]
+        self, unique_name: str, solver_list: "list[list]"
     ) -> None:
         self.root_solver_dict[unique_name] = solver_list
         self.add_solver_to_curr_exp_list(unique_name)
@@ -1579,7 +1579,7 @@ class NewExperimentWindow(Toplevel):
     def __insert_factors(
         self,
         frame: ttk.Frame,
-        factor_dict: dict[str, DFFactor],
+        factor_dict: "dict[str, DFFactor]",
         first_row: int = 2,
     ) -> int:
         """Insert the factors into the frame.
@@ -1609,7 +1609,9 @@ class NewExperimentWindow(Toplevel):
             factor_obj = factor_dict[factor_name]
             # Make a list of functions that will return the widgets for each
             # column in the frame
-            column_functions: list[Callable[[ttk.Frame], tk.Widget | None]] = [
+            column_functions: list[
+                Callable[[ttk.Frame], Union[tk.Widget, None]]
+            ] = [
                 factor_obj.get_name_label,
                 factor_obj.get_description_label,
                 factor_obj.get_type_label,
@@ -1746,7 +1748,7 @@ class NewExperimentWindow(Toplevel):
         return self.__get_unique_name(self.root_solver_dict, base_name)
 
     def __show_data_farming_core(
-        self, base_object: Solver | Problem, frame: ttk.Frame
+        self, base_object: Union[Solver, Problem], frame: ttk.Frame
     ) -> None:
         """Show data farming options for a solver or problem.
 
@@ -1942,9 +1944,9 @@ class NewExperimentWindow(Toplevel):
 
     def display_design_tree(
         self,
-        csv_filename: str | None = None,
-        design_table: pd.DataFrame | None = None,
-        master_frame: ttk.Frame | None = None,
+        csv_filename: Union[str, None] = None,
+        design_table: Union[pd.DataFrame, None] = None,
+        master_frame: Union[ttk.Frame, None] = None,
     ) -> None:
         if csv_filename is None and design_table is None:
             error_msg = "Either csv_filename or dataframe must be provided."
@@ -2111,7 +2113,7 @@ class NewExperimentWindow(Toplevel):
         # Hide the design tree
         self._hide_gen_design()
 
-    def __view_design(self, design_list: list[list]) -> None:
+    def __view_design(self, design_list: "list[list]") -> None:
         # Create an empty dataframe to display the design tree
         column_names = list(design_list[0][0].keys())
         num_rows = len(design_list)
@@ -2349,7 +2351,7 @@ class NewExperimentWindow(Toplevel):
             self.update()
             # Run the function
             try:
-                function(name)
+                function(name)  # type: ignore
                 # Set the name to include the updated status
                 name_label = self.tk_labels[lbl_name]
                 name_label.configure(text=name + "\n(" + future_tense + ")")
@@ -2778,7 +2780,7 @@ class NewExperimentWindow(Toplevel):
     def _find_option_setting_bool(
         self,
         exp_name: str,
-        search_dict: dict[str, tk.StringVar],
+        search_dict: "dict[str, tk.StringVar]",
         default_val: bool,
     ) -> bool:
         if exp_name in search_dict:
@@ -2792,7 +2794,7 @@ class NewExperimentWindow(Toplevel):
     def _find_option_setting_int(
         self,
         exp_name: str,
-        search_dict: dict[str, tk.IntVar],
+        search_dict: "dict[str, tk.IntVar]",
         default_val: int,
     ) -> int:
         if exp_name in search_dict:
@@ -3225,9 +3227,7 @@ class NewExperimentWindow(Toplevel):
             text="Refresh Dropdown",
             command=self.refresh_experiments,
         )
-        self.refresh_button.grid(
-            row=0, column=2, sticky="ew", padx=10
-        )
+        self.refresh_button.grid(row=0, column=2, sticky="ew", padx=10)
 
         self.select_plot_solvers_label = ttk.Label(
             master=self.plot_selection_frame,
@@ -3431,9 +3431,7 @@ class NewExperimentWindow(Toplevel):
             text="Load Plot from Pickle",
             command=self.load_plot,
         )
-        self.load_plot_button.grid(
-            row=0, column=1, padx=20, pady=10
-        )
+        self.load_plot_button.grid(row=0, column=1, padx=20, pady=10)
         # view selected plots button
         self.view_selected_plots_button = ttk.Button(
             master=self.plotting_workspace_frame,
@@ -4423,7 +4421,7 @@ class NewExperimentWindow(Toplevel):
         ]:  # disable if not correct plot type
             self.ref_solver_menu.configure(state="disabled")
 
-    def __get_plot_experiment_sublist(self) -> list[list[ProblemSolver]]:
+    def __get_plot_experiment_sublist(self) -> "list[list[ProblemSolver]]":
         # get selected solvers & problems
         exp_sublist = []  # sublist of experiments to be plotted (each index represents a group of problems over a single solver)
         for solver in self.selected_solvers:
@@ -4888,10 +4886,10 @@ class NewExperimentWindow(Toplevel):
 
     def add_plot_to_notebook(
         self,
-        file_paths: list[str],
-        solver_names: list[str],
-        problem_names: list[str],
-        parameters: dict | None = None,
+        file_paths: "list[str]",
+        solver_names: "list[str]",
+        problem_names: "list[str]",
+        parameters: Union[dict, None] = None,
     ) -> None:
         # add new tab for exp if applicable
         exp_name = self.experiment_var.get()
@@ -4998,9 +4996,7 @@ class NewExperimentWindow(Toplevel):
             screen_width = self.winfo_screenwidth()
             wrap_length = screen_width // 5
             path_label = ttk.Label(
-                master=tab_frame,
-                text=file_path,
-                wraplength=wrap_length
+                master=tab_frame, text=file_path, wraplength=wrap_length
             )
             path_label.grid(row=row, column=5, padx=5)
             para_label = ttk.Label(
@@ -5023,7 +5019,7 @@ class NewExperimentWindow(Toplevel):
                 self.plot_notebook.select(index)
 
     def delete_plot(
-        self, row: int, frame: tk.Frame, file_path: os.PathLike | str
+        self, row: int, frame: tk.Frame, file_path: Union[os.PathLike, str]
     ) -> None:
         for widget in frame.winfo_children():  # remove plot from list display
             info = widget.grid_info()
@@ -5097,7 +5093,7 @@ class NewExperimentWindow(Toplevel):
         self.plot_notebook.select(0)
 
     def view_plot(
-        self, file_path: os.PathLike | str
+        self, file_path: Union[os.PathLike, str]
     ) -> None:  # this window also allows for the editing of individual plots by accessing the created pickle file
         # create new window
         self.view_single_window = tk.Toplevel(self)
@@ -5251,8 +5247,8 @@ class NewExperimentWindow(Toplevel):
     def save_plot_changes(
         self,
         fig: plt.Figure,
-        pickle_path: os.PathLike | str,
-        file_path: os.PathLike | str,
+        pickle_path: Union[str, os.PathLike],
+        file_path: Union[str, os.PathLike],
         image_frame: tk.Frame,
         copy: bool = False,
     ) -> None:
@@ -5323,7 +5319,7 @@ class NewExperimentWindow(Toplevel):
             self.plot_notebook.select(0)
 
     def edit_plot_title(
-        self, file_path: os.PathLike | str, image_frame: tk.Frame
+        self, file_path: Union[os.PathLike, str], image_frame: tk.Frame
     ) -> None:
         # create new window
         self.edit_title_window = tk.Toplevel(self)
@@ -5488,8 +5484,8 @@ class NewExperimentWindow(Toplevel):
     def save_title_changes(
         self,
         fig: plt.figure,
-        pickle_path: os.PathLike | str,
-        file_path: os.PathLike | str,
+        pickle_path: Union[str, os.PathLike],
+        file_path: Union[str, os.PathLike],
         image_frame: tk.Frame,
         copy: bool = False,
     ) -> None:
@@ -5534,7 +5530,7 @@ class NewExperimentWindow(Toplevel):
         self.edit_title_window.destroy()  # close editing window
 
     def edit_plot_x_axis(
-        self, file_path: os.PathLike | str, image_frame: tk.Frame
+        self, file_path: Union[str, os.PathLike], image_frame: tk.Frame
     ) -> None:  # actualy edits both axes
         # create new window
         self.edit_x_axis_window = tk.Toplevel(self)
@@ -5567,7 +5563,7 @@ class NewExperimentWindow(Toplevel):
     def show_axis_options(
         self,
         axis: Literal["X-Axis", "Y-Axis"],
-        file_path: os.PathLike | str,
+        file_path: Union[str, os.PathLike],
         image_frame: tk.Frame,
     ) -> None:
         self._destroy_widget_children(self.edit_x_axis_frame)
@@ -5798,8 +5794,8 @@ class NewExperimentWindow(Toplevel):
     def save_x_axis_changes(
         self,
         fig: plt.figure,
-        pickle_path: os.PathLike | str,
-        file_path: os.PathLike | str,
+        pickle_path: Union[str, os.PathLike],
+        file_path: Union[str, os.PathLike],
         image_frame: tk.Frame,
         axis: Literal["X-Axis", "Y-Axis"],
         copy: bool = False,
@@ -5871,7 +5867,7 @@ class NewExperimentWindow(Toplevel):
         self.edit_x_axis_window.destroy()
 
     def edit_plot_text(
-        self, file_path: os.PathLike | str, image_frame: tk.Frame
+        self, file_path: Union[str, os.PathLike], image_frame: tk.Frame
     ) -> None:
         # create new window
         self.edit_text_window = tk.Toplevel(self)
@@ -6166,8 +6162,8 @@ class NewExperimentWindow(Toplevel):
     def save_text_changes(
         self,
         fig: plt.figure,
-        pickle_path: os.PathLike | str,
-        file_path: os.PathLike | str,
+        pickle_path: Union[str, os.PathLike],
+        file_path: Union[str, os.PathLike],
         image_frame: tk.Frame,
         text: Text,
         copy: bool = False,
@@ -6218,7 +6214,7 @@ class NewExperimentWindow(Toplevel):
         self.edit_text_window.destroy()
 
     def edit_plot_image(
-        self, file_path: os.PathLike | str, image_frame: tk.Frame
+        self, file_path: Union[str, os.PathLike], image_frame: tk.Frame
     ) -> None:
         # create new window
         self.edit_image_window = tk.Toplevel(self)
@@ -6280,8 +6276,8 @@ class NewExperimentWindow(Toplevel):
     def save_image_changes(
         self,
         fig: plt.figure,
-        pickle_path: os.PathLike | str,
-        file_path: os.PathLike | str,
+        pickle_path: Union[str, os.PathLike],
+        file_path: Union[str, os.PathLike],
         image_frame: tk.Frame,
         copy: bool = False,
     ) -> None:

--- a/simopt/solvers/astrodf.py
+++ b/simopt/solvers/astrodf.py
@@ -402,7 +402,7 @@ class ASTRODF(Solver):
                 elif i == 0:
                     sample_size = incumbent_solution.n_reps
                     sig2 = incumbent_solution.objectives_var[0]
-                    np.linalg.trace(incumbent_solution.objectives_gradients_var)
+                    np.trace(incumbent_solution.objectives_gradients_var)
                     # adaptive sampling
                     while True:
                         stopping = self.get_stopping_time(
@@ -425,7 +425,7 @@ class ASTRODF(Solver):
                         if delta_power == 0:
                             sig2 = max(
                                 sig2,
-                                np.linalg.trace(
+                                np.trace(
                                     incumbent_solution.objectives_gradients_var
                                 ),
                             )
@@ -452,7 +452,7 @@ class ASTRODF(Solver):
                     if delta_power == 0:
                         sig2 = max(
                             sig2,
-                            np.linalg.trace(
+                            np.trace(
                                 visited_pts_list[
                                     f_index
                                 ].objectives_gradients_var
@@ -480,7 +480,7 @@ class ASTRODF(Solver):
                         if delta_power == 0:
                             sig2 = max(
                                 sig2,
-                                np.linalg.trace(
+                                np.trace(
                                     visited_pts_list[
                                         f_index
                                     ].objectives_gradients_var
@@ -511,9 +511,7 @@ class ASTRODF(Solver):
                         if delta_power == 0:
                             sig2 = max(
                                 sig2,
-                                np.linalg.trace(
-                                    new_solution.objectives_gradients_var
-                                ),
+                                np.trace(new_solution.objectives_gradients_var),
                             )
                         stopping = self.get_stopping_time(
                             pilot_run,
@@ -737,9 +735,7 @@ class ASTRODF(Solver):
                 if delta_power == 0:
                     sig2 = max(
                         sig2,
-                        np.linalg.trace(
-                            incumbent_solution.objectives_gradients_var
-                        ),
+                        np.trace(incumbent_solution.objectives_gradients_var),
                     )
                 stopping = self.get_stopping_time(
                     pilot_run,
@@ -877,9 +873,7 @@ class ASTRODF(Solver):
             if delta_power == 0:
                 sig2 = max(
                     sig2,
-                    np.linalg.trace(
-                        candidate_solution.objectives_gradients_var
-                    ),
+                    np.trace(candidate_solution.objectives_gradients_var),
                 )
             stopping = self.get_stopping_time(
                 pilot_run, sig2, delta_k, kappa, problem.dim, delta_power

--- a/simopt/solvers/astrodf.py
+++ b/simopt/solvers/astrodf.py
@@ -231,7 +231,13 @@ class ASTRODF(Solver):
         return np.matmul(x_val, q)
 
     def get_stopping_time(
-        self, pilot_run: int, sig2: float, delta: float, kappa: float, dim: int, delta_power: int
+        self,
+        pilot_run: int,
+        sig2: float,
+        delta: float,
+        kappa: float,
+        dim: int,
+        delta_power: int,
     ) -> int:
         """
         Compute the sample size based on adaptive sampling stopping rule using the optimality gap
@@ -243,7 +249,9 @@ class ASTRODF(Solver):
         # ) * max(log(k + 0.1, 10) ** (1.01), 1)
 
         # compute sample size
-        raw_sample_size = pilot_run * max(1, sig2 / (kappa**2 * delta**delta_power))
+        raw_sample_size = pilot_run * max(
+            1, sig2 / (kappa**2 * delta**delta_power)
+        )
         # Convert out of ndarray if it is
         if isinstance(raw_sample_size, np.ndarray):
             raw_sample_size = raw_sample_size[0]
@@ -284,8 +292,8 @@ class ASTRODF(Solver):
         w = 0.85  # self.factors["w"]
         mu = 1000  # self.factors["mu"]
         beta = 10  # self.factors["beta"]
-        criticality_threshold = 0.1  # self.factors["criticality_threshold"]
-        skip_criticality = True  # self.factors["skip_criticality"]
+        # criticality_threshold = 0.1  # self.factors["criticality_threshold"]
+        # skip_criticality = True  # self.factors["skip_criticality"]
         j = 0
         # Problem and solver factors
         reuse_points: bool = self.factors["reuse_points"]
@@ -294,7 +302,13 @@ class ASTRODF(Solver):
 
         lambda_max = budget - expended_budget
         # lambda_max = budget / (15 * sqrt(problem.dim))
-        pilot_run = ceil( max(lambda_min * log(10+k, 10)**1.1, min(0.5 * problem.dim, lambda_max)) - 1)
+        pilot_run = ceil(
+            max(
+                lambda_min * log(10 + k, 10) ** 1.1,
+                min(0.5 * problem.dim, lambda_max),
+            )
+            - 1
+        )
         while True:
             fval = []
             j = j + 1
@@ -317,7 +331,12 @@ class ASTRODF(Solver):
 
             # If it is the first iteration or there is no design point we can reuse within the trust region, use the coordinate basis
 
-            if ( (k == 1) or ( norm(np.array(x_k) - np.array(visited_pts_list[f_index].x)) == 0 )
+            if (
+                (k == 1)
+                or (
+                    norm(np.array(x_k) - np.array(visited_pts_list[f_index].x))
+                    == 0
+                )
                 or not reuse_points
             ):
                 # Construct the interpolation set
@@ -339,8 +358,15 @@ class ASTRODF(Solver):
                 # if first_basis has some zero components, use coordinate basis for those dimensions
                 for i in range(problem.dim):
                     if first_basis[i] == 0:
-                        coord_vector = self.get_coordinate_vector(problem.dim, i)
-                        rotate_matrix = np.vstack( (rotate_matrix, coord_vector, ))
+                        coord_vector = self.get_coordinate_vector(
+                            problem.dim, i
+                        )
+                        rotate_matrix = np.vstack(
+                            (
+                                rotate_matrix,
+                                coord_vector,
+                            )
+                        )
 
                 # construct the interpolation set
                 var_y = self.get_rotated_basis_interpolation_points(
@@ -366,7 +392,11 @@ class ASTRODF(Solver):
             for i in range(2 * problem.dim + 1):
                 # for x_0, we don't need to simulate the new solution
                 if (k == 1) and (i == 0):
-                    fval.append(-1 * problem.minmax[0] * incumbent_solution.objectives_mean)
+                    fval.append(
+                        -1
+                        * problem.minmax[0]
+                        * incumbent_solution.objectives_mean
+                    )
                     interpolation_solns.append(incumbent_solution)
                 # reuse the replications for x_k (center point, i.e., the incumbent solution)
                 elif i == 0:
@@ -375,38 +405,98 @@ class ASTRODF(Solver):
                     np.linalg.trace(incumbent_solution.objectives_gradients_var)
                     # adaptive sampling
                     while True:
-                        stopping = self.get_stopping_time(pilot_run, sig2, delta_k, kappa, problem.dim, delta_power)
-                        if ( sample_size >= min(stopping, lambda_max) or expended_budget >= budget ):
+                        stopping = self.get_stopping_time(
+                            pilot_run,
+                            sig2,
+                            delta_k,
+                            kappa,
+                            problem.dim,
+                            delta_power,
+                        )
+                        if (
+                            sample_size >= min(stopping, lambda_max)
+                            or expended_budget >= budget
+                        ):
                             break
                         problem.simulate(incumbent_solution, 1)
                         expended_budget += 1
                         sample_size += 1
                         sig2 = incumbent_solution.objectives_var[0]
-                        if delta_power == 0: sig2 = max(sig2, np.linalg.trace(incumbent_solution.objectives_gradients_var))  
-                    fval.append(-1 * problem.minmax[0] * incumbent_solution.objectives_mean)
+                        if delta_power == 0:
+                            sig2 = max(
+                                sig2,
+                                np.linalg.trace(
+                                    incumbent_solution.objectives_gradients_var
+                                ),
+                            )
+                    fval.append(
+                        -1
+                        * problem.minmax[0]
+                        * incumbent_solution.objectives_mean
+                    )
                     interpolation_solns.append(incumbent_solution)
                 # else if reuse one design point, reuse the replications
-                elif ((i == 1) and (norm(np.array(x_k) - np.array(visited_pts_list[f_index].x))!= 0)
+                elif (
+                    (i == 1)
+                    and (
+                        norm(
+                            np.array(x_k)
+                            - np.array(visited_pts_list[f_index].x)
+                        )
+                        != 0
+                    )
                     and reuse_points
                 ):
                     sample_size = visited_pts_list[f_index].n_reps
                     sig2 = visited_pts_list[f_index].objectives_var[0]
-                    if delta_power == 0: sig2 = max(sig2, np.linalg.trace(visited_pts_list[f_index].objectives_gradients_var))   
+                    if delta_power == 0:
+                        sig2 = max(
+                            sig2,
+                            np.linalg.trace(
+                                visited_pts_list[
+                                    f_index
+                                ].objectives_gradients_var
+                            ),
+                        )
                     # adaptive sampling
                     while True:
-                        stopping = self.get_stopping_time(pilot_run, sig2, delta_k, kappa, problem.dim, delta_power)
-                        if (sample_size >= min(stopping, lambda_max) or expended_budget >= budget ):
+                        stopping = self.get_stopping_time(
+                            pilot_run,
+                            sig2,
+                            delta_k,
+                            kappa,
+                            problem.dim,
+                            delta_power,
+                        )
+                        if (
+                            sample_size >= min(stopping, lambda_max)
+                            or expended_budget >= budget
+                        ):
                             break
                         problem.simulate(visited_pts_list[f_index], 1)
                         expended_budget += 1
                         sample_size += 1
                         sig2 = visited_pts_list[f_index].objectives_var[0]
-                        if delta_power == 0: sig2 = max(sig2, np.linalg.trace(visited_pts_list[f_index].objectives_gradients_var))  
-                    fval.append(-1 * problem.minmax[0] * visited_pts_list[f_index].objectives_mean )
+                        if delta_power == 0:
+                            sig2 = max(
+                                sig2,
+                                np.linalg.trace(
+                                    visited_pts_list[
+                                        f_index
+                                    ].objectives_gradients_var
+                                ),
+                            )
+                    fval.append(
+                        -1
+                        * problem.minmax[0]
+                        * visited_pts_list[f_index].objectives_mean
+                    )
                     interpolation_solns.append(visited_pts_list[f_index])
                 # for new points, run the simulation with pilot run
                 else:
-                    new_solution = self.create_new_solution(tuple(var_y[i][0]), problem)
+                    new_solution = self.create_new_solution(
+                        tuple(var_y[i][0]), problem
+                    )
                     visited_pts_list.append(new_solution)
                     problem.simulate(new_solution, pilot_run)
                     expended_budget += pilot_run
@@ -418,11 +508,29 @@ class ASTRODF(Solver):
                         expended_budget += 1
                         sample_size += 1
                         sig2 = new_solution.objectives_var[0]
-                        if delta_power == 0: sig2 = max(sig2, np.linalg.trace(new_solution.objectives_gradients_var))
-                        stopping = self.get_stopping_time(pilot_run, sig2, delta_k, kappa, problem.dim, delta_power)
-                        if ( sample_size >= min(stopping, lambda_max) or expended_budget >= budget ):
+                        if delta_power == 0:
+                            sig2 = max(
+                                sig2,
+                                np.linalg.trace(
+                                    new_solution.objectives_gradients_var
+                                ),
+                            )
+                        stopping = self.get_stopping_time(
+                            pilot_run,
+                            sig2,
+                            delta_k,
+                            kappa,
+                            problem.dim,
+                            delta_power,
+                        )
+                        if (
+                            sample_size >= min(stopping, lambda_max)
+                            or expended_budget >= budget
+                        ):
                             break
-                    fval.append(-1 * problem.minmax[0] * new_solution.objectives_mean)
+                    fval.append(
+                        -1 * problem.minmax[0] * new_solution.objectives_mean
+                    )
                     interpolation_solns.append(new_solution)
 
             # construct the model and obtain the model coefficients
@@ -483,7 +591,9 @@ class ASTRODF(Solver):
         is_block_constraint = sum(x_k) != 0
 
         for var_idx in range(num_decision_vars):
-            coord_vector = self.get_coordinate_vector( num_decision_vars, var_idx )
+            coord_vector = self.get_coordinate_vector(
+                num_decision_vars, var_idx
+            )
             coord_diff = delta * coord_vector
             minus = y_var[0] - coord_diff
             plus = y_var[0] + coord_diff
@@ -585,15 +695,25 @@ class ASTRODF(Solver):
         # uncomment the next line to avoid Hessian updating
         # h_k = np.identity(problem.dim)
         # determine power of delta in adaptive sampling rule
-        if self.factors["crn_across_solns"] == True:
-            if gradient_availability: delta_power = 0
-            else: delta_power = 2
+        if self.factors["crn_across_solns"]:
+            if gradient_availability:
+                delta_power = 0
+            else:
+                delta_power = 2
         else:
             delta_power = 4
-        
-        pilot_run = ceil(max(lambda_min * log(10+k, 10)**1.1, min(0.5 * problem.dim, lambda_max)) - 1)
+
+        pilot_run = ceil(
+            max(
+                lambda_min * log(10 + k, 10) ** 1.1,
+                min(0.5 * problem.dim, lambda_max),
+            )
+            - 1
+        )
         if k == 1:
-            incumbent_solution = self.create_new_solution(tuple(incumbent_x), problem)
+            incumbent_solution = self.create_new_solution(
+                tuple(incumbent_x), problem
+            )
             if len(visited_pts_list) == 0:
                 visited_pts_list.append(incumbent_solution)
 
@@ -608,15 +728,39 @@ class ASTRODF(Solver):
                 expended_budget += 1
                 sample_size += 1
                 if gradient_availability:
-                    rhs_for_kappa = norm(incumbent_solution.objectives_gradients_mean[0])
+                    rhs_for_kappa = norm(
+                        incumbent_solution.objectives_gradients_mean[0]
+                    )
                 else:
                     rhs_for_kappa = incumbent_solution.objectives_mean
                 sig2 = incumbent_solution.objectives_var[0]
-                if delta_power == 0: sig2 = max(sig2, np.linalg.trace(incumbent_solution.objectives_gradients_var))
-                stopping = self.get_stopping_time( pilot_run, sig2, delta_k, rhs_for_kappa * np.sqrt(pilot_run) / (delta_k**(delta_power/2)), problem.dim, delta_power)
-                if (sample_size >= min(stopping, lambda_max) or expended_budget >= budget_limit ):
+                if delta_power == 0:
+                    sig2 = max(
+                        sig2,
+                        np.linalg.trace(
+                            incumbent_solution.objectives_gradients_var
+                        ),
+                    )
+                stopping = self.get_stopping_time(
+                    pilot_run,
+                    sig2,
+                    delta_k,
+                    rhs_for_kappa
+                    * np.sqrt(pilot_run)
+                    / (delta_k ** (delta_power / 2)),
+                    problem.dim,
+                    delta_power,
+                )
+                if (
+                    sample_size >= min(stopping, lambda_max)
+                    or expended_budget >= budget_limit
+                ):
                     # calculate kappa
-                    kappa = rhs_for_kappa * np.sqrt(pilot_run) / (delta_k**(delta_power/2))
+                    kappa = (
+                        rhs_for_kappa
+                        * np.sqrt(pilot_run)
+                        / (delta_k ** (delta_power / 2))
+                    )
                     # print("kappa "+str(kappa))
                     break
 
@@ -625,11 +769,20 @@ class ASTRODF(Solver):
 
         # use Taylor expansion if gradient available
         if gradient_availability:
-            fval = np.ones(2*problem.dim+1)* -1 * problem.minmax[0] * incumbent_solution.objectives_mean
-            grad = -1 * problem.minmax[0] * incumbent_solution.objectives_gradients_mean[0]
+            fval = (
+                np.ones(2 * problem.dim + 1)
+                * -1
+                * problem.minmax[0]
+                * incumbent_solution.objectives_mean
+            )
+            grad = (
+                -1
+                * problem.minmax[0]
+                * incumbent_solution.objectives_gradients_mean[0]
+            )
             hessian = h_k
         else:
-        # build the local model with interpolation (subproblem)
+            # build the local model with interpolation (subproblem)
             (
                 fval,
                 y_var,
@@ -649,9 +802,9 @@ class ASTRODF(Solver):
                 kappa,
                 incumbent_solution,
                 visited_pts_list,
-                delta_power
+                delta_power,
             )
-        
+
         # solve the local model (subproblem)
         if easy_solve:
             # Cauchy reduction
@@ -659,21 +812,25 @@ class ASTRODF(Solver):
             # print("np.dot(np.multiply(grad, Hessian), grad) "+str(np.dot(np.multiply(grad, hessian), grad)))
             # print("np.dot(np.dot(grad, hessian), grad) "+str(np.dot(np.dot(grad, hessian), grad)))
             if gradient_availability:
-                print("hessian "+str(hessian))
+                # print("hessian " + str(hessian))
                 check_positive_definite = np.dot(np.dot(grad, hessian), grad)
             else:
-                check_positive_definite = np.dot(np.multiply(grad, hessian), grad)
+                check_positive_definite = np.dot(
+                    np.multiply(grad, hessian), grad
+                )
             if check_positive_definite <= 0:
                 tau = 1
             else:
-                tau = min(1, norm(grad) ** 3 / (delta_k * check_positive_definite))
+                tau = min(
+                    1, norm(grad) ** 3 / (delta_k * check_positive_definite)
+                )
                 # print("tau "+str(tau))
             grad = np.reshape(grad, (1, problem.dim))[0]
             candidate_x = incumbent_x - tau * delta_k * grad / norm(grad)
-            if norm(incumbent_x - candidate_x) > 0:
-                print("incumbent_x "+str(incumbent_x))
-                print("candidate_x "+str(candidate_x))
-            
+            # if norm(incumbent_x - candidate_x) > 0:
+            #     print("incumbent_x " + str(incumbent_x))
+            #     print("candidate_x " + str(candidate_x))
+
         else:
             # Search engine - solve subproblem
             def subproblem(s: np.ndarray) -> float:
@@ -703,7 +860,9 @@ class ASTRODF(Solver):
                 candidate_x[i] = problem.upper_bounds[i] - 0.01
 
         # store the solution (and function estimate at it) to the subproblem as a candidate for the next iterate
-        candidate_solution = self.create_new_solution(tuple(candidate_x), problem)
+        candidate_solution = self.create_new_solution(
+            tuple(candidate_x), problem
+        )
         visited_pts_list.append(candidate_solution)
 
         # pilot run and adaptive sampling
@@ -715,10 +874,21 @@ class ASTRODF(Solver):
             expended_budget += 1
             sample_size += 1
             sig2 = candidate_solution.objectives_var[0]
-            if delta_power == 0: sig2 = max(sig2, np.linalg.trace(candidate_solution.objectives_gradients_var))  
-            stopping = self.get_stopping_time(pilot_run, sig2, delta_k, kappa, problem.dim, delta_power)
+            if delta_power == 0:
+                sig2 = max(
+                    sig2,
+                    np.linalg.trace(
+                        candidate_solution.objectives_gradients_var
+                    ),
+                )
+            stopping = self.get_stopping_time(
+                pilot_run, sig2, delta_k, kappa, problem.dim, delta_power
+            )
             # print("stopping "+str(stopping))
-            if ( sample_size >= min(stopping, lambda_max) or expended_budget >= budget_limit):
+            if (
+                sample_size >= min(stopping, lambda_max)
+                or expended_budget >= budget_limit
+            ):
                 break
 
         # TODO: make sure the solution whose estimated objevtive is abrupted bc of budget is not added to the list of recommended solutions, unless the error is negligible ...
@@ -731,9 +901,24 @@ class ASTRODF(Solver):
         # also if the candidate solution's variance is high that could be caused by stopping early due to exhausting budget
         # print("cv "+str(candidate_solution.objectives_var/(candidate_solution.n_reps * candidate_solution.objectives_mean ** 2)))
         # print("fval[0] - min(fval) "+str(fval[0] - min(fval)))
-        if (gradient_availability == False and 
-            ((min(fval) < fval_tilde) and ((fval[0] - min(fval)) >= self.factors["ps_sufficient_reduction"] * delta_k**2)
-            or ((candidate_solution.objectives_var/(candidate_solution.n_reps * candidate_solution.objectives_mean ** 2))[0] > 0.75))
+        if not gradient_availability and (
+            (
+                (min(fval) < fval_tilde)
+                and (
+                    (fval[0] - min(fval))
+                    >= self.factors["ps_sufficient_reduction"] * delta_k**2
+                )
+            )
+            or (
+                (
+                    candidate_solution.objectives_var
+                    / (
+                        candidate_solution.n_reps
+                        * candidate_solution.objectives_mean**2
+                    )
+                )[0]
+                > 0.75
+            )
         ):
             fval_tilde = min(fval)
             candidate_x = y_var[fval.index(min(fval))][0]
@@ -742,9 +927,13 @@ class ASTRODF(Solver):
         # compute the success ratio rho
         s = np.array(candidate_x - incumbent_x)
         if gradient_availability:
-            model_reduction = -np.dot(s, grad)-0.5*np.dot(np.dot(s, hessian), s)
+            model_reduction = -np.dot(s, grad) - 0.5 * np.dot(
+                np.dot(s, hessian), s
+            )
         else:
-            model_reduction = self.evaluate_model(np.zeros(problem.dim), q) - self.evaluate_model(s, q)
+            model_reduction = self.evaluate_model(
+                np.zeros(problem.dim), q
+            ) - self.evaluate_model(s, q)
         if model_reduction <= 0:
             rho = 0
         else:
@@ -758,20 +947,30 @@ class ASTRODF(Solver):
             intermediate_budgets.append(expended_budget)
             delta_k = min(delta_k, delta_max)
             # very successful: expand
-            if rho >= eta_2: delta_k = min(gamma_1 * delta_k, delta_max)
+            if rho >= eta_2:
+                delta_k = min(gamma_1 * delta_k, delta_max)
             if gradient_availability:
-                candidate_grad = -1 * problem.minmax[0] * candidate_solution.objectives_gradients_mean[0]
-                y_k = np.array(candidate_grad - grad) #np.clip(candidate_grad - grad, 1e-5, np.inf)
+                candidate_grad = (
+                    -1
+                    * problem.minmax[0]
+                    * candidate_solution.objectives_gradients_mean[0]
+                )
+                y_k = np.array(
+                    candidate_grad - grad
+                )  # np.clip(candidate_grad - grad, 1e-5, np.inf)
                 # Compute the intermediate terms for the SMW update
                 r_k = 1.0 / (y_k @ s)
                 h_s_k = h_k @ s
-                h_k = h_k + (np.outer(y_k, y_k) * r_k - np.outer(h_s_k, h_s_k) / (s @ h_s_k))
+                h_k = h_k + (
+                    np.outer(y_k, y_k) * r_k
+                    - np.outer(h_s_k, h_s_k) / (s @ h_s_k)
+                )
         # unsuccessful: shrink and reject
         else:
             delta_k = min(gamma_2 * delta_k, delta_max)
             final_ob = fval[0]
 
-        # TODO: unified TR management 
+        # TODO: unified TR management
         # delta_k = min(kappa * norm(grad), delta_max)
         # print("norm of grad "+str(norm(grad)))
         return (
@@ -784,7 +983,7 @@ class ASTRODF(Solver):
             kappa,
             incumbent_solution,
             visited_pts_list,
-            h_k
+            h_k,
         )
 
     def solve(self, problem: Problem) -> tuple[list[Solution], list[int]]:
@@ -828,18 +1027,22 @@ class ASTRODF(Solver):
             ]
         # TODO: update this so that it could be used for problems with decision variables at varying scales!
         delta_max = max(delta_max_arr)
-        print("delta_max  "+str(delta_max))
+        # print("delta_max  " + str(delta_max))
         # Reset iteration and data storage arrays
         visited_pts_list = []
         k = 0
         delta_k = 10 ** (ceil(log(delta_max * 2, 10) - 1) / problem.dim)
-        print("initial delta "+str(delta_k))
-        incumbent_x: tuple[int | float, ...] = problem.factors["initial_solution"]
+        # print("initial delta " + str(delta_k))
+        incumbent_x: tuple[int | float, ...] = problem.factors[
+            "initial_solution"
+        ]
         expended_budget, kappa = 0, 0
         recommended_solns, intermediate_budgets = [], []
-        incumbent_solution = self.create_new_solution(tuple(incumbent_x), problem)
+        incumbent_solution = self.create_new_solution(
+            tuple(incumbent_x), problem
+        )
         h_k = np.identity(problem.dim)
-        
+
         while expended_budget < budget:
             k += 1
             (
@@ -852,7 +1055,7 @@ class ASTRODF(Solver):
                 kappa,
                 incumbent_solution,
                 visited_pts_list,
-                h_k
+                h_k,
             ) = self.iterate(
                 k,
                 delta_k,
@@ -866,7 +1069,7 @@ class ASTRODF(Solver):
                 intermediate_budgets,
                 kappa,
                 incumbent_solution,
-                h_k
+                h_k,
             )
 
         return recommended_solns, intermediate_budgets


### PR DESCRIPTION
Changelog:
- Replaced `X | Y` with `Union[X, Y]` for typing
- Replaced `np.linalg.trace` with `np.trace` since `np.linalg.trace` was introduced in Numpy 2.0 
which requires a minimum of Python 3.9
- Added divide-by-0 handling into ASTRO-DF (I think it got removed when it got updated recently)
- Fixed ASTRO-DF formatting issues
- Commented out print statements in ASTRO-DF so they wouldn't print during runtime