### PR TITLE
Improve Divide-By-Zero Handling

### DIFF
--- a/simopt/experiment_base.py
+++ b/simopt/experiment_base.py
@@ -27,6 +27,7 @@ from simopt.directory import (
     problem_directory,
     solver_directory,
 )
+from simopt.utils import make_nonzero
 
 # Imports exclusively used when type checking
 # Prevents imports from being executed at runtime
@@ -1529,20 +1530,7 @@ def post_normalize(
     initial_obj_val = np.mean(x0_postreps)
     opt_obj_val = np.mean(xstar_postreps)
     initial_opt_gap = initial_obj_val - opt_obj_val
-    # Make sure initial_opt_gap is not equal to zero.
-    # This prevents a divide-by-zero error later on.
-    epsilon = 1e-15
-    if np.isclose(initial_opt_gap, 0, atol=epsilon):
-        warning_msg = (
-            f"initial_opt_gap is {initial_opt_gap}. "
-            f"Setting to {epsilon} to avoid divide-by-zero error."
-        )
-        logging.warning(warning_msg)
-        initial_opt_gap = (
-            epsilon
-            if initial_opt_gap == 0
-            else np.sign(initial_opt_gap) * epsilon
-        )
+    initial_opt_gap = make_nonzero(initial_opt_gap, "initial_opt_gap")
     # Store x0 and x* info and compute progress curves for each ProblemSolver.
     for experiment in experiments:
         # DOUBLE-CHECK FOR SHALLOW COPY ISSUES.

--- a/simopt/solvers/strong.py
+++ b/simopt/solvers/strong.py
@@ -324,7 +324,7 @@ class STRONG(Solver):
                         np.subtract(candidate_x, new_x),
                     )
                 )
-                r_diff = float(r_old - r_new)
+                r_diff = (r_old - r_new)[0]
                 r_diff = make_nonzero(r_diff, "r_diff (stage I)")
                 rho = g_diff / r_diff
 
@@ -419,7 +419,7 @@ class STRONG(Solver):
                         np.subtract(candidate_x, new_x),
                     )
                 )
-                r_diff = r_old - r_new
+                r_diff = (r_old - r_new)[0]
                 r_diff = make_nonzero(r_diff, "rdiff (stage II)")
                 rho = g_diff / r_diff
                 # Step 4: Update the trust region size and determine to accept or reject the solution.
@@ -541,7 +541,7 @@ class STRONG(Solver):
                         rr_old = g_b_old
                         # Set rho to the ratio.
                         g_b_diff = g_b_old - g_b_new
-                        rr_diff = rr_old - rr_new
+                        rr_diff = (rr_old - rr_new)[0]
                         rr_diff = make_nonzero(rr_diff, "rr_diff")
                         rrho = (g_b_diff) / (rr_diff)
 

--- a/simopt/solvers/strong.py
+++ b/simopt/solvers/strong.py
@@ -9,10 +9,9 @@ A detailed description of the solver can be found
 
 from __future__ import annotations
 
-import logging
 import math
 from typing import Callable, Literal
-from simopt.utils import classproperty
+from simopt.utils import classproperty, make_nonzero
 
 import numpy as np
 from numpy.linalg import norm
@@ -325,19 +324,9 @@ class STRONG(Solver):
                         np.subtract(candidate_x, new_x),
                     )
                 )
-                r_diff = r_old - r_new
-                if r_diff == 0:
-                    warning_msg = "Division by zero in STRONG solver (r_diff == 0 (Step I_3))"
-                    logging.warning(warning_msg)
-                    # Follow IEEE 754 standard.
-                    if g_diff < 0:
-                        rho = -np.inf
-                    elif g_diff > 0:
-                        rho = np.inf
-                    else:
-                        rho = np.nan
-                else:
-                    rho = g_diff / r_diff
+                r_diff = float(r_old - r_new)
+                r_diff = make_nonzero(r_diff, "r_diff (stage I)")
+                rho = g_diff / r_diff
 
                 # Step 4: Update the trust region size and determine to accept or reject the solution.
                 if (rho < eta_0) | (g_diff <= 0) | (r_diff <= 0):
@@ -431,12 +420,8 @@ class STRONG(Solver):
                     )
                 )
                 r_diff = r_old - r_new
-                if r_diff == 0:
-                    warning_msg = "Division by zero in STRONG solver (r_diff == 0 (Step II_3))"
-                    logging.warning(warning_msg)
-                    rho = 0
-                else:
-                    rho = g_diff / r_diff
+                r_diff = make_nonzero(r_diff, "rdiff (stage II)")
+                rho = g_diff / r_diff
                 # Step 4: Update the trust region size and determine to accept or reject the solution.
                 if (rho < eta_0) | (g_diff <= 0) | (r_diff <= 0):
                     # Inner Loop.
@@ -557,12 +542,8 @@ class STRONG(Solver):
                         # Set rho to the ratio.
                         g_b_diff = g_b_old - g_b_new
                         rr_diff = rr_old - rr_new
-                        if rr_diff == 0:
-                            warning_msg = "Division by zero in STRONG solver (rr_diff == 0)"
-                            logging.warning(warning_msg)
-                            rrho = 0
-                        else:
-                            rrho = (g_b_diff) / (rr_diff)
+                        rr_diff = make_nonzero(rr_diff, "rr_diff")
+                        rrho = (g_b_diff) / (rr_diff)
 
                         if (
                             (rrho < eta_0)

--- a/simopt/utils.py
+++ b/simopt/utils.py
@@ -16,3 +16,23 @@ class ClassPropertyDescriptor:
 def classproperty(func: Callable[[type[T]], Any]) -> ClassPropertyDescriptor:
     """Decorator to create a class property using a descriptor."""
     return ClassPropertyDescriptor(func)
+
+
+def make_nonzero(value: float, name: str, epsilon: float = 1e-15) -> None:
+    """Return a non-zero value to avoid division by zero."""
+    # Delayed imports
+    import numpy as np
+
+    # If it's not close to 0, return the original value
+    if not np.isclose(value, 0, atol=epsilon):
+        return value
+
+    # Otherwise, calculate the new value
+    import logging
+
+    new_value = epsilon if value == 0 else np.sign(value) * epsilon
+    warning_msg = (
+        f"{name} is {value}. Setting to {new_value} to avoid division by zero."
+    )
+    logging.warning(warning_msg)
+    return new_value

--- a/simopt/utils.py
+++ b/simopt/utils.py
@@ -18,8 +18,23 @@ def classproperty(func: Callable[[type[T]], Any]) -> ClassPropertyDescriptor:
     return ClassPropertyDescriptor(func)
 
 
-def make_nonzero(value: float, name: str, epsilon: float = 1e-15) -> None:
-    """Return a non-zero value to avoid division by zero."""
+def make_nonzero(value: float, name: str, epsilon: float = 1e-15) -> float:
+    """Return a non-zero value to avoid division by zero.
+
+    Arguments
+    ---------
+    value : float
+        The value to check.
+    name : str
+        The name of the variable.
+    epsilon : float, optional (default=1e-15)
+        The value to use if the original value is zero.
+
+    Returns
+    -------
+    float
+        The original value if it's not close to zero, otherwise a non-zero value.
+    """
     # Delayed imports
     import numpy as np
 

--- a/test/expected_results/CNTNEWS1_ALOE.yaml
+++ b/test/expected_results/CNTNEWS1_ALOE.yaml
@@ -20,35 +20,25 @@ all_est_objectives:
 - - 0.0
   - 0.0
 all_intermediate_budgets:
-- &id011
-  - 0
+- - 0
   - 1000
-- &id013
-  - 0
+- - 0
   - 1000
-- &id014
-  - 0
+- - 0
   - 1000
-- &id015
-  - 0
+- - 0
   - 1000
-- &id016
-  - 0
+- - 0
   - 1000
-- &id017
-  - 0
+- - 0
   - 1000
-- &id018
-  - 0
+- - 0
   - 1000
-- &id019
-  - 0
+- - 0
   - 1000
-- &id020
-  - 0
+- - 0
   - 1000
-- &id021
-  - 0
+- - 0
   - 1000
 all_recommended_xs:
 - - &id001 !!python/tuple
@@ -85,168 +75,145 @@ num_macroreps: 10
 num_postreps: 100
 objective_curves:
 - !!python/tuple
-  - *id011
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - &id012 !!python/object/apply:numpy.dtype
-        args:
-        - f8
-        - false
-        - true
-        state: !!python/tuple
-        - 3
-        - <
-        - null
-        - null
-        - null
-        - -1
-        - -1
-        - 0
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id013
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id014
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id015
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id016
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id017
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id018
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id019
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id020
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id021
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 problem_name: CNTNEWS-1
 progress_curves:
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 solver_name: ALOE

--- a/test/expected_results/CNTNEWS1_STRONG.yaml
+++ b/test/expected_results/CNTNEWS1_STRONG.yaml
@@ -20,35 +20,25 @@ all_est_objectives:
 - - 0.0
   - 0.0
 all_intermediate_budgets:
-- &id011
-  - 10
+- - 10
   - 1000
-- &id013
-  - 10
+- - 10
   - 1000
-- &id014
-  - 10
+- - 10
   - 1000
-- &id015
-  - 10
+- - 10
   - 1000
-- &id016
-  - 10
+- - 10
   - 1000
-- &id017
-  - 10
+- - 10
   - 1000
-- &id018
-  - 10
+- - 10
   - 1000
-- &id019
-  - 10
+- - 10
   - 1000
-- &id020
-  - 10
+- - 10
   - 1000
-- &id021
-  - 10
+- - 10
   - 1000
 all_recommended_xs:
 - - &id001 !!python/tuple
@@ -85,168 +75,145 @@ num_macroreps: 10
 num_postreps: 100
 objective_curves:
 - !!python/tuple
-  - *id011
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - &id012 !!python/object/apply:numpy.dtype
-        args:
-        - f8
-        - false
-        - true
-        state: !!python/tuple
-        - 3
-        - <
-        - null
-        - null
-        - null
-        - -1
-        - -1
-        - 0
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id013
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id014
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id015
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id016
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id017
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id018
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id019
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id020
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - *id021
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        AAAAAAAAAAA=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 0.0
+    - 0.0
 problem_name: CNTNEWS-1
 progress_curves:
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 solver_name: STRONG

--- a/test/expected_results/EXAMPLE1_SPSA.yaml
+++ b/test/expected_results/EXAMPLE1_SPSA.yaml
@@ -1,7 +1,9 @@
 all_est_objectives:
 - - 8.045027962356473
   - 8.045027962356473
+  - 8.045027962356473
 - - 8.05008884111451
+  - 8.05008884111451
   - 8.05008884111451
 - - 7.819069853409974
   - 7.819069853409974
@@ -21,6 +23,7 @@ all_est_objectives:
   - 5.676234609014099
 - - 8.015549761383689
   - 8.015549761383689
+  - 8.015549761383689
 - - 8.011665588713441
   - 8.011665588713441
   - 7.4325303394106745
@@ -38,6 +41,8 @@ all_est_objectives:
   - 6.100962545244181
   - 6.100962545244181
 - - 8.024598344668116
+  - 8.024598344668116
+  - 8.024598344668116
   - 8.024598344668116
 - - 7.857717639230737
   - 7.077717639230734
@@ -57,23 +62,18 @@ all_est_objectives:
   - 6.383072056262604
 - - 8.158743092618227
   - 8.158743092618227
-  - 8.158743092618227
-  - 8.158743092618227
 - - 7.978687945786026
-  - 7.978687945786026
   - 7.978687945786026
 - - 8.008030375047568
   - 8.008030375047568
-  - 8.008030375047568
 all_intermediate_budgets:
-- &id012
-  - 0
+- - 0
+  - 210
   - 1000
-- &id013
-  - 0
+- - 0
+  - 210
   - 1000
-- &id014
-  - 0
+- - 0
   - 210
   - 270
   - 330
@@ -89,11 +89,10 @@ all_intermediate_budgets:
   - 930
   - 990
   - 1000
-- &id015
-  - 0
+- - 0
+  - 210
   - 1000
-- &id016
-  - 0
+- - 0
   - 210
   - 270
   - 330
@@ -109,11 +108,11 @@ all_intermediate_budgets:
   - 930
   - 990
   - 1000
-- &id017
-  - 0
+- - 0
+  - 210
+  - 270
   - 1000
-- &id018
-  - 0
+- - 0
   - 210
   - 270
   - 330
@@ -129,34 +128,19 @@ all_intermediate_budgets:
   - 930
   - 990
   - 1000
-- &id019
-  - 0
-  - 210
-  - 270
+- - 0
   - 1000
-- &id020
-  - 0
-  - 210
+- - 0
   - 1000
-- &id021
-  - 0
-  - 210
+- - 0
   - 1000
 all_recommended_xs:
-- - &id001 !!python/tuple
-    - 2.0
-    - 2.0
-  - *id001
-- - &id002 !!python/tuple
-    - 2.0
-    - 2.0
-  - *id002
 - - !!python/tuple
     - 2.0
     - 2.0
-  - !!python/tuple
+  - &id002 !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - &id003 !!python/object/apply:numpy.dtype
+      - &id001 !!python/object/apply:numpy.dtype
         args:
         - f8
         - false
@@ -173,392 +157,445 @@ all_recommended_xs:
       - !!binary |
         AAAAAAAAAEA=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+  - *id002
+- - !!python/tuple
+    - 2.0
+    - 2.0
+  - &id003 !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+  - *id003
+- - !!python/tuple
+    - 2.0
+    - 2.0
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
       - !!binary |
         AAAAAAAAAEA=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         AAAAAAAAAEA=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         AAAAAAAAAEA=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         9qpgwvMK/z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         9qpgwvMK/z8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         bfET+nhA/j8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         bfET+nhA/j8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         eFjHLUOT/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        eFjHLUOT/T8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        eFjHLUOT/T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         eFjHLUOT/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
+      - !!binary |
+        eFjHLUOT/T8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        eFjHLUOT/T8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
       - !!binary |
         9LeUbUUJ/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         9LeUbUUJ/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         LDha8KeM/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         LDha8KeM/D8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         WkVX2fEa/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        WkVX2fEa/D8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        WkVX2fEa/D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         WkVX2fEa/D8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
+      - !!binary |
+        WkVX2fEa/D8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        WkVX2fEa/D8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
       - !!binary |
         qLYSt424+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         qLYSt424+z8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         qLYSt424+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         qLYSt424+z8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         KCdrvIZh+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         KCdrvIZh+z8=
   - &id004 !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         KCdrvIZh+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         KCdrvIZh+z8=
   - *id004
-- - &id005 !!python/tuple
+- - !!python/tuple
     - 2.0
     - 2.0
+  - &id005 !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
   - *id005
 - - !!python/tuple
     - 2.0
     - 2.0
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         AAAAAAAAAEA=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         AAAAAAAAAEA=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         wrgrs+nR/j8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        wrgrs+nR/j8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        wrgrs+nR/j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         wrgrs+nR/j8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         wrgrs+nR/j8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        wrgrs+nR/j8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        wrgrs+nR/j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         wrgrs+nR/j8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
+      - !!binary |
+        wrgrs+nR/j8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        wrgrs+nR/j8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        wrgrs+nR/j8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        wrgrs+nR/j8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
       - !!binary |
         cD5Bycwz/j8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         cD5Bycwz/j8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         1EYsAeKm/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         1EYsAeKm/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         89BPF6An/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         89BPF6An/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         TQ6tw4Cz/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         TQ6tw4Cz/D8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Gx9weaVI/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Gx9weaVI/D8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Gx9weaVI/D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Gx9weaVI/D8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
+      - !!binary |
+        Gx9weaVI/D8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Gx9weaVI/D8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
       - !!binary |
         D6Nt/RPr+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         D6Nt/RPr+z8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         D6Nt/RPr+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         D6Nt/RPr+z8=
   - &id006 !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         D6Nt/RPr+z8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         D6Nt/RPr+z8=
   - *id006
-- - &id007 !!python/tuple
+- - !!python/tuple
     - 2.0
     - 2.0
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+  - &id007 !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        AAAAAAAAAEA=
   - *id007
 - - !!python/tuple
     - 2.0
     - 2.0
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         ZmZmZmZm/j8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         ZmZmZmZm/j8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-  - !!python/tuple
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        Uryc0GpH/T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         Uryc0GpH/T8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
+      - !!binary |
+        Uryc0GpH/T8=
+  - !!python/tuple
+    - !!python/object/apply:numpy._core.multiarray.scalar
+      - *id001
       - !!binary |
         M8SPf47m/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         M8SPf47m/D8=
   - !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         M8SPf47m/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         M8SPf47m/D8=
   - &id008 !!python/tuple
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         M8SPf47m/D8=
     - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
+      - *id001
       - !!binary |
         M8SPf47m/D8=
   - *id008
@@ -566,55 +603,57 @@ all_recommended_xs:
     - 2.0
     - 2.0
   - *id009
-  - *id009
-  - *id009
 - - &id010 !!python/tuple
     - 2.0
     - 2.0
-  - *id010
   - *id010
 - - &id011 !!python/tuple
     - 2.0
     - 2.0
   - *id011
-  - *id011
 num_macroreps: 10
 num_postreps: 100
 objective_curves:
 - !!python/tuple
-  - *id012
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
+    - 8.045027962356473
 - !!python/tuple
-  - *id013
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
+    - 8.045027962356473
 - !!python/tuple
-  - *id014
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 270.0
+    - 330.0
+    - 390.0
+    - 450.0
+    - 510.0
+    - 570.0
+    - 630.0
+    - 690.0
+    - 750.0
+    - 810.0
+    - 870.0
+    - 930.0
+    - 990.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
+    - 8.045027962356473
     - 7.347619170075763
     - 6.968868166045438
     - 6.652624907034803
@@ -629,25 +668,35 @@ objective_curves:
     - 5.676234609014099
     - 5.676234609014099
 - !!python/tuple
-  - *id015
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
+    - 8.045027962356473
 - !!python/tuple
-  - *id016
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 270.0
+    - 330.0
+    - 390.0
+    - 450.0
+    - 510.0
+    - 570.0
+    - 630.0
+    - 690.0
+    - 750.0
+    - 810.0
+    - 870.0
+    - 930.0
+    - 990.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
     - 7.4325303394106745
     - 7.4325303394106745
     - 7.4325303394106745
@@ -663,21 +712,36 @@ objective_curves:
     - 6.100962545244181
     - 6.100962545244181
 - !!python/tuple
-  - *id017
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 270.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
+    - 8.045027962356473
+    - 8.045027962356473
 - !!python/tuple
-  - *id018
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 270.0
+    - 330.0
+    - 390.0
+    - 450.0
+    - 510.0
+    - 570.0
+    - 630.0
+    - 690.0
+    - 750.0
+    - 810.0
+    - 870.0
+    - 930.0
+    - 990.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
     - 7.077717639230734
     - 6.555048076734993
     - 6.555048076734993
@@ -694,77 +758,49 @@ objective_curves:
     - 6.383072056262604
     - 6.383072056262604
 - !!python/tuple
-  - *id019
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
 - !!python/tuple
-  - *id020
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
 - !!python/tuple
-  - *id021
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AXSz5w0XIEA=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 8.045027962356473
+    - 8.045027962356473
 problem_name: EXAMPLE-1
 progress_curves:
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
+    - 0.21
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-- !!python/tuple
-  - - 0.0
+  - !!python/tuple
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
+    - 1.0
+    - 1.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
+    - 0.21
+    - 1.0
+  - !!python/tuple
+    - 1.0
+    - 1.0
+    - 1.0
+- !!python/tuple
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 0.27
     - 0.33
@@ -780,83 +816,35 @@ progress_curves:
     - 0.93
     - 0.99
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        l8RmuNk57T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        l9WeIC646z8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        GIEz2ih26j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        GIEz2ih26j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        F4AJENR66T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        HezB/9Sb6D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        w+c9PKPT5z8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        w+c9PKPT5z8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        RZfcxvIo5z8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        RZfcxvIo5z8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        KWZPku6T5j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        KWZPku6T5j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        KWZPku6T5j8=
-- !!python/tuple
-  - - 0.0
+  - !!python/tuple
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
+    - 1.0
+    - 1.0
+    - 0.9133118249502726
+    - 0.866232932769594
+    - 0.8269237767927136
+    - 0.8269237767927136
+    - 0.7962436974739856
+    - 0.7690224643005227
+    - 0.7445846726034165
+    - 0.7445846726034165
+    - 0.7237485775010347
+    - 0.7237485775010347
+    - 0.7055580957050483
+    - 0.7055580957050483
+    - 0.7055580957050483
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
+    - 0.21
+    - 1.0
+  - !!python/tuple
+    - 1.0
+    - 1.0
+    - 1.0
+- !!python/tuple
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 0.27
     - 0.33
@@ -872,83 +860,37 @@ progress_curves:
     - 0.93
     - 0.99
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        v6M3F1CQ7T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        v6M3F1CQ7T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        v6M3F1CQ7T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        v6M3F1CQ7T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        YNJ6w3xk7D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        xEzjimJe6z8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        aqQF69R16j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        g5y3wg6l6T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        N9C7qNXn6D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        N9C7qNXn6D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        TW98SGtE6D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        TW98SGtE6D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        TW98SGtE6D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        TW98SGtE6D8=
-- !!python/tuple
-  - - 0.0
+  - !!python/tuple
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
+    - 1.0
+    - 0.9238663152183263
+    - 0.9238663152183263
+    - 0.9238663152183263
+    - 0.9238663152183263
+    - 0.8872665231670673
+    - 0.8552715981153587
+    - 0.8268837538027018
+    - 0.8013986399718224
+    - 0.7783001227931042
+    - 0.7783001227931042
+    - 0.7583519378417606
+    - 0.7583519378417606
+    - 0.7583519378417606
+    - 0.7583519378417606
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
+    - 0.21
+    - 0.27
+    - 1.0
+  - !!python/tuple
+    - 1.0
+    - 1.0
+    - 1.0
+    - 1.0
+- !!python/tuple
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 0.27
     - 0.33
@@ -964,121 +906,42 @@ progress_curves:
     - 0.93
     - 0.99
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        KVZmqAQn7D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        FmCW1swS6j8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        rpHBrq5j6T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        rpHBrq5j6T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        rpHBrq5j6T8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        rpHBrq5j6T8=
-- !!python/tuple
-  - - 0.0
-    - 0.21
-    - 0.27
+  - !!python/tuple
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
+    - 0.8797629632051144
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.8147949401054599
+    - 0.7934182561116836
+    - 0.7934182561116836
+    - 0.7934182561116836
+    - 0.7934182561116836
 - !!python/tuple
-  - - 0.0
-    - 0.21
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
+  - !!python/tuple
+    - 1.0
+    - 1.0
 - !!python/tuple
-  - - 0.0
-    - 0.21
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id003
-      - !!binary |
-        AAAAAAAA8D8=
+  - !!python/tuple
+    - 1.0
+    - 1.0
+- !!python/tuple
+  - !!python/tuple
+    - 0.0
+    - 1.0
+  - !!python/tuple
+    - 1.0
+    - 1.0
 solver_name: SPSA

--- a/test/expected_results/IRONORECONT1_ALOE.yaml
+++ b/test/expected_results/IRONORECONT1_ALOE.yaml
@@ -20,35 +20,25 @@ all_est_objectives:
 - - 172226.47681338942
   - 172226.47681338942
 all_intermediate_budgets:
-- &id011
-  - 0
+- - 0
   - 1000
-- &id013
-  - 0
+- - 0
   - 1000
-- &id014
-  - 0
+- - 0
   - 1000
-- &id015
-  - 0
+- - 0
   - 1000
-- &id016
-  - 0
+- - 0
   - 1000
-- &id017
-  - 0
+- - 0
   - 1000
-- &id018
-  - 0
+- - 0
   - 1000
-- &id019
-  - 0
+- - 0
   - 1000
-- &id020
-  - 0
+- - 0
   - 1000
-- &id021
-  - 0
+- - 0
   - 1000
 all_recommended_xs:
 - - &id001 !!python/tuple
@@ -105,168 +95,145 @@ num_macroreps: 10
 num_postreps: 100
 objective_curves:
 - !!python/tuple
-  - *id011
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - &id012 !!python/object/apply:numpy.dtype
-        args:
-        - f8
-        - false
-        - true
-        state: !!python/tuple
-        - 3
-        - <
-        - null
-        - null
-        - null
-        - -1
-        - -1
-        - 0
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id013
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id014
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id015
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id016
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id017
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id018
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id019
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id020
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id021
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id012
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 problem_name: IRONORECONT-1
 progress_curves:
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 solver_name: ALOE

--- a/test/expected_results/IRONORECONT1_SPSA.yaml
+++ b/test/expected_results/IRONORECONT1_SPSA.yaml
@@ -35,49 +35,39 @@ all_est_objectives:
   - 171178.91767060646
   - 171178.91767060646
 all_intermediate_budgets:
-- &id012
-  - 0
+- - 0
   - 330
   - 1000
-- &id013
-  - 0
+- - 0
   - 270
   - 1000
-- &id014
-  - 0
+- - 0
   - 210
   - 1000
-- &id015
-  - 0
+- - 0
   - 1000
-- &id016
-  - 0
+- - 0
   - 1000
-- &id017
-  - 0
+- - 0
   - 210
   - 1000
-- &id018
-  - 0
+- - 0
   - 330
   - 450
   - 690
   - 1000
-- &id019
-  - 0
+- - 0
   - 270
   - 330
   - 1000
-- &id020
-  - 0
+- - 0
   - 210
   - 270
   - 690
   - 810
   - 870
   - 1000
-- &id021
-  - 0
+- - 0
   - 210
   - 1000
 all_recommended_xs:
@@ -343,82 +333,90 @@ num_macroreps: 10
 num_postreps: 100
 objective_curves:
 - !!python/tuple
-  - *id012
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 330.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 143703.80380981145
     - 143703.80380981145
 - !!python/tuple
-  - *id013
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 270.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 124484.36530911895
     - 124484.36530911895
 - !!python/tuple
-  - *id014
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 2767.251336613593
     - 2767.251336613593
 - !!python/tuple
-  - *id015
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id016
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id017
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 123425.60221072758
     - 123425.60221072758
 - !!python/tuple
-  - *id018
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 330.0
+    - 450.0
+    - 690.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 138953.39463979824
     - 137478.9506210003
     - 135479.72132039454
     - 135479.72132039454
 - !!python/tuple
-  - *id019
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 270.0
+    - 330.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 158764.36152011174
     - 158700.34277161688
     - 158700.34277161688
 - !!python/tuple
-  - *id020
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 270.0
+    - 690.0
+    - 810.0
+    - 870.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 159751.55689350533
     - 159671.87180783367
     - 159926.85115486226
@@ -426,93 +424,114 @@ objective_curves:
     - 159124.48680240626
     - 159124.48680240626
 - !!python/tuple
-  - *id021
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 0.0
+    - 210.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 171178.91767060646
     - 171178.91767060646
 problem_name: IRONORECONT-1
 progress_curves:
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.33
     - 1.0
-  - - .nan
-    - .inf
-    - .inf
+  - !!python/tuple
+    - 0.0
+    - 9.003108102875994e+17
+    - 9.003108102875994e+17
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.27
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.8319127690404899e+19
+    - -1.8319127690404899e+19
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.4003624166291025e+20
+    - -1.4003624166291025e+20
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.937789078879627e+19
+    - -1.937789078879627e+19
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.33
     - 0.45
     - 0.69
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -3.8500983597256125e+18
+    - -5.324542378523561e+18
+    - -7.323771679129305e+18
+    - -7.323771679129305e+18
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.27
     - 0.33
     - 1.0
-  - - .nan
-    - .inf
-    - .inf
-    - .inf
+  - !!python/tuple
+    - 0.0
+    - 1.5960868520587885e+19
+    - 1.589684977209303e+19
+    - 1.589684977209303e+19
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 0.27
     - 0.69
     - 0.81
     - 0.87
     - 1.0
-  - - .nan
-    - .inf
-    - .inf
-    - .inf
-    - .inf
-    - .inf
-    - .inf
+  - !!python/tuple
+    - 0.0
+    - 1.694806389398148e+19
+    - 1.6868378808309817e+19
+    - 1.7123358155338412e+19
+    - 1.6814503249416737e+19
+    - 1.632099380288241e+19
+    - 1.632099380288241e+19
 - !!python/tuple
-  - - 0.0
+  - !!python/tuple
+    - 0.0
     - 0.21
     - 1.0
-  - - .nan
-    - .inf
-    - .inf
+  - !!python/tuple
+    - 0.0
+    - 2.837542467108261e+19
+    - 2.837542467108261e+19
 solver_name: SPSA

--- a/test/expected_results/IRONORECONT1_STRONG.yaml
+++ b/test/expected_results/IRONORECONT1_STRONG.yaml
@@ -41,39 +41,32 @@ all_est_objectives:
   - 167480.72306951438
   - 167480.72306951438
 all_intermediate_budgets:
-- &id012
-  - 10
+- - 10
   - 80
   - 1000
-- &id013
-  - 10
+- - 10
   - 157
   - 241
   - 1000
-- &id014
-  - 10
+- - 10
   - 80
   - 157
   - 241
   - 535
   - 647
   - 1000
-- &id015
-  - 10
+- - 10
   - 80
   - 157
   - 946
   - 1000
-- &id016
-  - 10
+- - 10
   - 80
   - 1000
-- &id017
-  - 10
+- - 10
   - 80
   - 1000
-- &id018
-  - 10
+- - 10
   - 157
   - 241
   - 332
@@ -81,15 +74,12 @@ all_intermediate_budgets:
   - 535
   - 647
   - 1000
-- &id019
-  - 10
+- - 10
   - 430
   - 1000
-- &id020
-  - 10
+- - 10
   - 1000
-- &id021
-  - 10
+- - 10
   - 157
   - 1000
 all_recommended_xs:
@@ -433,28 +423,36 @@ num_macroreps: 10
 num_postreps: 100
 objective_curves:
 - !!python/tuple
-  - *id012
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 80.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 127087.75301385323
     - 127087.75301385323
 - !!python/tuple
-  - *id013
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 157.0
+    - 241.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 121032.12009497327
     - 127045.51899143969
     - 127045.51899143969
 - !!python/tuple
-  - *id014
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 80.0
+    - 157.0
+    - 241.0
+    - 535.0
+    - 647.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 128519.35425249879
     - 119260.53944898426
     - 128768.7584623664
@@ -462,37 +460,48 @@ objective_curves:
     - 128643.93374899424
     - 128643.93374899424
 - !!python/tuple
-  - *id015
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 80.0
+    - 157.0
+    - 946.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 144226.94711823962
     - 137007.8737508123
     - 142199.63315839774
     - 142199.63315839774
 - !!python/tuple
-  - *id016
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 80.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 127633.68087959175
     - 127633.68087959175
 - !!python/tuple
-  - *id017
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 80.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 117247.51915758578
     - 117247.51915758578
 - !!python/tuple
-  - *id018
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 157.0
+    - 241.0
+    - 332.0
+    - 430.0
+    - 535.0
+    - 647.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 124513.558985401
     - 139755.7894514133
     - 124866.54733630833
@@ -501,91 +510,103 @@ objective_curves:
     - 139286.81463267293
     - 139286.81463267293
 - !!python/tuple
-  - *id019
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 430.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 151012.2699427192
     - 151012.2699427192
 - !!python/tuple
-  - *id020
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
-    - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
+    - 142803.49299952385
 - !!python/tuple
-  - *id021
-  - - !!python/object/apply:numpy._core.multiarray.scalar
-      - *id001
-      - !!binary |
-        /7up8ZtuAUE=
+  - !!python/tuple
+    - 10.0
+    - 157.0
+    - 1000.0
+  - !!python/tuple
+    - 142803.49299952385
     - 167480.72306951438
     - 167480.72306951438
 problem_name: IRONORECONT-1
 progress_curves:
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.08
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.5715739985670617e+19
+    - -1.5715739985670617e+19
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.157
     - 0.241
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -2.177137290455057e+19
+    - -1.5757974008084156e+19
+    - -1.5757974008084156e+19
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.08
     - 0.157
     - 0.241
     - 0.535
     - 0.647
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.4284138747025062e+19
+    - -2.3542953550539588e+19
+    - -1.4034734537157448e+19
+    - -3.712694801003672e+18
+    - -1.4159559250529608e+19
+    - -1.4159559250529608e+19
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.08
     - 0.157
     - 0.946
     - 1.0
-  - - .nan
-    - .inf
-    - -.inf
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - 1.4234541187157737e+18
+    - -5.795619248711562e+18
+    - -6.038598411261046e+17
+    - -6.038598411261046e+17
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.08
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.5169812119932103e+19
+    - -1.5169812119932103e+19
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.08
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -2.555597384193807e+19
+    - -2.555597384193807e+19
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.157
     - 0.241
     - 0.332
@@ -593,31 +614,38 @@ progress_curves:
     - 0.535
     - 0.647
     - 1.0
-  - - .nan
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
-    - -.inf
+  - !!python/tuple
+    - 0.0
+    - -1.8289934014122844e+19
+    - -3.0477035481105556e+18
+    - -1.7936945663215518e+19
+    - -3.5175711244077824e+18
+    - -1.7737920127406686e+19
+    - -3.516678366850916e+18
+    - -3.516678366850916e+18
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.43
     - 1.0
-  - - .nan
-    - .inf
-    - .inf
+  - !!python/tuple
+    - 0.0
+    - 8.208776943195349e+18
+    - 8.208776943195349e+18
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 1.0
-  - - .nan
-    - .nan
+  - !!python/tuple
+    - 0.0
+    - 0.0
 - !!python/tuple
-  - - 0.01
+  - !!python/tuple
+    - 0.01
     - 0.157
     - 1.0
-  - - .nan
-    - .inf
-    - .inf
+  - !!python/tuple
+    - 0.0
+    - 2.467723006999053e+19
+    - 2.467723006999053e+19
 solver_name: STRONG


### PR DESCRIPTION
- Introduced `make_nonzero()` function to make checking/correcting potential divide-by-zero errors easier
- Updated Strong and SPSA solvers and `post_normalize()` to utilize this new function
- Regenerated some CNTNEWS1 and IRONORECONT1 test results that had `0`s instead of `nan`s after `post_normalize()` behavior changed
- Regenerated test results for EXAMPLE1 with SPSA as the new divide-by-0 behavior slightly changed run results for SPSA. Other tests for SPSA were not affected and thus didn't need regenerated.

ASTRO-DF behavior still needs refactored (pending merge of PR #149 into dev)