### PR TITLE
Relax Dependencies + Add Dependency Groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "seaborn>=0.13.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 build = ["setuptools>=61.0"]
 dev = ["jupytext==1.17.3", "ruff==0.14.6", "ty==0.0.1a28"]
 docs = ["sphinx>=8.2.0", "sphinx-autoapi>=3.6.0", "sphinx-rtd-theme>=3.0.0"]


### PR DESCRIPTION
## Linked Issue (Required)
Fixes #188 

## The Fix

### Relaxed Core Dependency Requirements

| Dependency Name | Old Minimum | New Minimum | Reasoning |
| -| - | - | - |
| `numpy` | 2.3.4 | 2.0.0 | Breaking changes between v1.X and v2.X |
| `cvxpy` | 1.7.3 | 1.6.0 | Oldest version compatible with `numpy` v2 |
| `matplotlib` | 3.10.7 | 3.9.0 | Oldest version compatible with `numpy` v2 |
| `pandas` | 2.3.3 | 2.2.2 | Oldest version compatible with `numpy` v2 |
| `scipy` | 1.16.3 | 1.13.0 | Oldest version compatible with `numpy` v2 |
| `pydantic` | 2.12.3 | 2.2.0 | Oldest version compatible with `numpy` v2 that didn't raise serialized value warnings |
| `boltons` | 25.0.0 | 0.6.3 | Oldest version with `typeutils` |
| `joblib` | 1.5.2 | 1.0.0 | Oldest stable version |
| `seaborn` | 0.13.2 | 0.13.0 | `density_norm` has a different name in prior versions |

The process for establishing the new minimums was performed by pinning a package to a specific version and advancing/regressing the pinned version until warnings/errors were raised while running the regression test suite or until tests in the suite failed. Plotting packages were tested manually via notebooks and the GUI since the regression test suite does not utilize any plots. The pinning and version adjustment was repeated for each package with the environment being rebuilt after each adjustment to ensure any inter-dependency requirements were satisfied.

### Removed Unused Core `pillow` Dependency

It was not used anywhere in the current codebase.

### Relaxed Optional Dependency Versions

This followed the same process as the relaxing of the core dependencies.

### Added Additional Optional Dependency Groups

- **build**: additional packages required for building the `simoptlib` package
  - `setuptools>=61.0`: the build-system currently used to build the package, version constraint matches existing minimum (see top of `pyproject.toml`)
- **testing**: additional packages required to run the included testing suite
  - `pyyaml>=6.0`: expected results are stored in `.yaml` files which cannot be opened without a `yaml` library of some sort. v6.0.3 is the newest version, so v6.0 was selected as the minimum since it works and is quite old (>4 years) so users should easily be able to resolve a compatible version
  - `pytest` and `pytest-xdist` were moved from the `dev` group to the `testing` group

### Changed `project.optional-dependencies` to `dependency-groups`

`project.optional-dependencies` is meant for user-facing optional dependencies while `dependency-groups` is meant for dev-facing optional dependencies. Since none of the dependency groups are useful to end-users who are dealing solely with the published package, the dependency groups should be listed under `dependency-groups` instead.

### Pinned `dev` Dependency Versions

`ruff` and `ty` were both pinned to their latest versions so that they would not unexpectedly update and cause GitHub actions to error unexpectedly. Additionally, `jupytext` was pinned since `jupytext` writes its version in each `<notebook>.py`'s metadata header, so pinning it to a specific version like 1.17.3 (the version used to create the files) prevents repeated unnecessary updates to the metadata header.

### Additional Notes

I'm marking this as a bug fix (and thus merging to main) since the current high dependency requirements can result in unsolvable dependencies for any downstream packages.

## Verification
- [X] `ruff check` passes on my code
- [X] `ty check` passes on my code
- [X] The bug is reproducible on the `master` branch.
- [X] The bug is NO LONGER reproducible on this branch.
- [X] All tests in the `tests` directory are passing.