### PR TITLE
Include `data_farming` Module in Wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,14 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["simopt", "simopt.gui", "simopt.models", "simopt.solvers"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["simopt*"]
+# Ignore the build directory so we don't circularly include built distributions.
+exclude = ["build*"]
+
+[tool.setuptools.package-data]
+"simopt.data_farming" = ["*.npz"]
 
 [project]
 name = "simoptlib"


### PR DESCRIPTION
fixes #191 

## Changes
* Switches from including only predefined modules in the built wheel (which can lead to errors if nobody includes them before publishing the wheel, see above) to including all modules starting with `simopt`
* Includes all compressed numpy data in the `simopt.data_farming` module (currently only `nolhs_design_table.npz` which is necessary for `nolhs.py` to function) in the built wheel