### PR TITLE
Fix: Update `pyproject.toml` Metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -22,11 +22,19 @@ authors = [
 ]
 description = "A testbed for simulation-optimization experiments."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11,<3.14"
 classifiers = [
+  # Application Info
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Mathematics",
+  # Python Versions
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  # Other Classifiers
   "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -57,3 +65,4 @@ notebooks = ["ipykernel>=7.1.0"]
 [project.urls]
 "Homepage" = "https://github.com/simopt-admin/simopt"
 "Documentation" = "https://simopt.readthedocs.io/en/latest/"
+"Issues" = "https://github.com/simopt-admin/simopt/issues"


### PR DESCRIPTION
## Linked Issue (Required)
Fixes #209 

## The Fix
- Fixed the use of the deprecated license expression as outlined in the issue by replacing it with distinct `license` and `license-files` parameters. These options were added in `setuptools` v77.0.0, so the minimum version was bumped to support that. I don't believe there is a way around this bump if we still wish to include a license file (which we should absolutely include).
- Added additional classifiers to better convey the audience of the library and what Python versions are supported
- Added an "issues" label to the project URL section. See [well-known labels](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels) for other labels we can add in the future (if applicable).

## Verification
- [X] `ruff check` passes on my code
- [X] `ty check` passes on my code
- [X] The bug is reproducible on the `master` branch.
- [X] The bug is NO LONGER reproducible on this branch.
- [X] All tests in the `tests` directory are passing.